### PR TITLE
fixes the pnpm install race condition on mac

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+store-dir=/pnpm-store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
 FROM node:22.6.0-bookworm
 
 RUN corepack enable pnpm
-RUN pnpm config set store-dir /pnpm-store
-
-


### PR DESCRIPTION
Running pnpm install (through docker compose) on a mac device would lead to some sort of race condition between docker's volume syncing and pnpm's store and cause inconsistent ENOENT errors. A previous commit almost solved the issue by putting pnpm store in a named volume instead of the binding volume. 

However, when I tried running it on my device the `RUN pnpm config set store-dir /pnpm-store` didn't seem to properly define the pnpm-store's location. It was still using `/mono/.pnpm-store` as the store location which was inside the bind volume and thus didn't remove the race condition. I tried a few different suggested ways (using global flag, using env vars) to set the store path following pnpm's docs but the only one that seemed to work in the current setup was using a .npmrc file