### PR TITLE
Limit number of attempts that can be made to auth using OTP 

### DIFF
--- a/apps/jonogon-core/src/api/trpc/procedures/auth/common.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/auth/common.mts
@@ -1,0 +1,26 @@
+import type {TContext} from '../../context.mjs';
+
+export const getNumberOfAttempts = async (
+    ctx: TContext,
+    key: string,
+    ttl: number,
+): Promise<number> => {
+    return (await ctx.services.redisConnection.eval(
+        // this is lua code
+        `
+            local current
+            current = redis.call("incr", KEYS[1])
+            
+            -- only run the expire command on first run
+            if current == 1 then
+                -- expire the key after 1 hour
+                redis.call("expire", KEYS[1], ARGV[1])
+            end
+            
+            return current
+        `,
+        1,
+        key,
+        ttl,
+    )) as number;
+};


### PR DESCRIPTION
The limit is necessary otherwise the OTP (4 digits) can easily be brute forced.