### PR TITLE
fix: prevent image carousel arrows from overlapping navbar

### DIFF
--- a/apps/jonogon-web/src/app/components/custom/Navigation.tsx
+++ b/apps/jonogon-web/src/app/components/custom/Navigation.tsx
@@ -32,7 +32,7 @@ const Navigation = observer(() => {
     }, [selfDataResponse?.data.name]);
 
     return (
-        <div className="border-b border-neutral-300 fixed w-full top-0 left-0 z-[10] bg-background">
+        <div className="border-b border-neutral-300 fixed w-full top-0 left-0 z-[50] bg-background">
             <nav className="max-w-screen-sm mx-auto h-20 flex items-center justify-between px-4">
                 <Link href="/" className="flex items-center gap-2">
                     <img src="/images/icon.svg" alt="logo" className="w-12" />


### PR DESCRIPTION
The z-index of the navigation bar has been increased to ensure it always appears above the carousel arrows, resolving the layering issue when scrolling. Referring to this issue https://github.com/jonogon/jonogon-mono/issues/17 