### PR TITLE
Added image preview in petition card

### DIFF
--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -116,15 +116,7 @@ export const listPetitions = publicProcedure
             .with('first_attachment', (db) => {
                 return db
                     .selectFrom('petition_attachments')
-                    .select([
-                        'petition_id',
-                        'id as attachment_id',
-                        'filename as attachment_filename',
-                        'created_at as attachment_created_at',
-                        'is_image as attachment_is_image',
-                        'thumbnail as attachment_thumbnail',
-                        'attachment as attachment_url',
-                    ])
+                    .select(['petition_id', 'attachment as attachment_url'])
                     .where('deleted_at', 'is', null)
                     .distinctOn('petition_id')
                     .orderBy('petition_id')
@@ -150,11 +142,6 @@ export const listPetitions = publicProcedure
                 'result_with_downvotes.petition_upvote_count',
                 'result_with_downvotes.petition_downvote_count',
                 'votes.vote as user_vote',
-                'first_attachment.attachment_id',
-                'first_attachment.attachment_filename',
-                'first_attachment.attachment_created_at',
-                'first_attachment.attachment_is_image',
-                'first_attachment.attachment_thumbnail',
                 'first_attachment.attachment_url',
             ])
             .groupBy([
@@ -164,11 +151,6 @@ export const listPetitions = publicProcedure
                 'result_with_downvotes.petition_upvote_count',
                 'result_with_downvotes.petition_downvote_count',
                 'votes.vote',
-                'first_attachment.attachment_id',
-                'first_attachment.attachment_filename',
-                'first_attachment.attachment_created_at',
-                'first_attachment.attachment_is_image',
-                'first_attachment.attachment_thumbnail',
                 'first_attachment.attachment_url',
             ]);
 
@@ -213,25 +195,10 @@ export const listPetitions = publicProcedure
                             picture: petition.user_picture,
                         },
                         status: deriveStatus(petition),
-                        attachment: petition.attachment_id
-                            ? {
-                                  id: petition.attachment_id,
-                                  filename: petition.attachment_filename,
-                                  created_at: petition.attachment_created_at,
-                                  type: petition.attachment_is_image
-                                      ? 'image'
-                                      : 'file',
-                                  thumbnail: petition.attachment_thumbnail
-                                      ? await ctx.services.fileStorage.getFileURL(
-                                            petition.attachment_thumbnail,
-                                        )
-                                      : null,
-                                  attachment: petition.attachment_url
-                                      ? await ctx.services.fileStorage.getFileURL(
-                                            petition.attachment_url,
-                                        )
-                                      : null,
-                              }
+                        attachment: petition.attachment_url
+                            ? await ctx.services.fileStorage.getFileURL(
+                                  petition.attachment_url,
+                              )
                             : null,
                     },
                     extras: {

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -131,7 +131,12 @@ export const listPetitions = publicProcedure
                         .orderBy('petition_id')
                         .orderBy('created_at')
                         .as('first_attachment'),
-                (join) => join.onRef('petitions.id', '=', 'first_attachment.petition_id')
+                (join) =>
+                    join.onRef(
+                        'petitions.id',
+                        '=',
+                        'first_attachment.petition_id',
+                    ),
             )
             .selectAll('petitions')
             .select([
@@ -161,43 +166,41 @@ export const listPetitions = publicProcedure
 
         return {
             input,
-            data: await Promise.all(
-                data.map(async (petition) => ({
-                    data: {
-                        ...pick(petition, [
-                            'id',
-                            'title',
-                            'location',
-                            'target',
-                            'created_at',
-                            'submitted_at',
-                            'rejected_at',
-                            'rejection_reason',
-                            'approved_at',
-                            'formalized_at',
-                            'petition_upvote_count',
-                            'petition_downvote_count',
-                        ]),
-                        created_by: {
-                            id: petition.created_by,
-                            name: petition.user_name,
-                            picture: petition.user_picture,
-                        },
-                        status: deriveStatus(petition),
-                        attachment: petition.attachment_url
-                            ? await ctx.services.fileStorage.getFileURL(
-                                  petition.attachment_url,
-                              )
-                            : null,
+            data: data.map((petition) => ({
+                data: {
+                    ...pick(petition, [
+                        'id',
+                        'title',
+                        'location',
+                        'target',
+                        'created_at',
+                        'submitted_at',
+                        'rejected_at',
+                        'rejection_reason',
+                        'approved_at',
+                        'formalized_at',
+                        'petition_upvote_count',
+                        'petition_downvote_count',
+                    ]),
+                    created_by: {
+                        id: petition.created_by,
+                        name: petition.user_name,
+                        picture: petition.user_picture,
                     },
-                    extras: {
-                        user_vote: petition.user_vote,
-                        user: {
-                            name: petition.user_name,
-                            picture: petition.user_picture,
-                        },
+                    status: deriveStatus(petition),
+                    attachment: petition.attachment_url
+                        ? ctx.services.fileStorage.getFileURL(
+                              petition.attachment_url,
+                          )
+                        : null,
+                },
+                extras: {
+                    user_vote: petition.user_vote,
+                    user: {
+                        name: petition.user_name,
+                        picture: petition.user_picture,
                     },
-                })),
-            ),
+                },
+            })),
         };
     });

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -121,6 +121,11 @@ export const listPetitions = publicProcedure
                     .onRef('petitions.id', '=', 'votes.petition_id')
                     .on('votes.user_id', '=', `${ctx.auth?.user_id ?? 0}`),
             )
+            .leftJoin('petition_attachments as attachments', (join) =>
+                join
+                    .onRef('petitions.id', '=', 'attachments.petition_id')
+                    .on('attachments.deleted_at', 'is', null),
+            )
             .selectAll('petitions')
             .select([
                 'users.name as user_name',
@@ -128,6 +133,16 @@ export const listPetitions = publicProcedure
                 'result_with_downvotes.petition_upvote_count',
                 'result_with_downvotes.petition_downvote_count',
                 'votes.vote as user_vote',
+                'attachments.attachment as attachment_url',
+            ])
+            .groupBy([
+                'petitions.id',
+                'users.name',
+                'users.picture',
+                'result_with_downvotes.petition_upvote_count',
+                'result_with_downvotes.petition_downvote_count',
+                'votes.vote',
+                'attachments.attachment',
             ]);
 
         const data =
@@ -170,6 +185,7 @@ export const listPetitions = publicProcedure
                         picture: petition.user_picture,
                     },
                     status: deriveStatus(petition),
+                    attachment_url: petition.attachment_url,
                 },
                 extras: {
                     user_vote: petition.user_vote,

--- a/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
@@ -31,36 +31,14 @@ export default function PetitionCard(props: {
     return (
         <Card className={''}>
             <CardHeader className={''}>
-                {/* <Image
-                    src={`${props.attachment.attachment}`.replace(
-                        '$CORE_HOSTNAME',
-                        window.location.hostname,
-                    )}
-                    className="w-full h-full bg-red-500"
-                    alt={props.attachment.filename ?? 'Untitled Petition'}
-                    width={300}
-                    height={200}
-                /> */}
                 <img
                     src={`${props.attachment.attachment}`.replace(
                         '$CORE_HOSTNAME',
                         window.location.hostname,
                     )}
-                    className="w-full h-full bg-red-500"
+                    className="w-full h-full bg-red-500 rounded-lg"
                 />
                 <CardTitle>
-                    <div
-                        className={
-                            'font-normal text-base text-neutral-500 pb-2'
-                        }>
-                        {props.name},{' '}
-                        <time
-                            dateTime={props.date.toISOString()}
-                            suppressHydrationWarning>
-                            {formatDate(props.date)}
-                        </time>{' '}
-                        — To, <i>{props.target}</i>
-                    </div>
                     <div>
                         <Link
                             href={`/petitions/${props.id}`}
@@ -69,6 +47,22 @@ export default function PetitionCard(props: {
                             }>
                             {props.title}
                         </Link>
+                    </div>
+                    <div
+                        className={
+                            'font-normal text-base text-neutral-500 pb-2'
+                        }>
+                        <div>
+                            {props.name},{' '}
+                            <time
+                                dateTime={props.date.toISOString()}
+                                suppressHydrationWarning>
+                                {formatDate(props.date)}
+                            </time>{' '}
+                        </div>
+                        <div>
+                            — To, <i>{props.target}</i>
+                        </div>
                     </div>
                 </CardTitle>
             </CardHeader>

--- a/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
@@ -14,7 +14,7 @@ export default function PetitionCard(props: {
     date: Date;
     target: string;
     title: string;
-    attachment: any;
+    attachment: string;
 
     status: string;
 
@@ -31,9 +31,9 @@ export default function PetitionCard(props: {
     return (
         <Card className={''}>
             <CardHeader className={''}>
-                {props.attachment.attachment && (
+                {props.attachment && (
                     <img
-                        src={`${props.attachment.attachment}`.replace(
+                        src={`${props.attachment}`.replace(
                             '$CORE_HOSTNAME',
                             window.location.hostname,
                         )}

--- a/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
@@ -14,14 +14,7 @@ export default function PetitionCard(props: {
     date: Date;
     target: string;
     title: string;
-    attachment: {
-        id: string;
-        type: string;
-        attachment: string | null;
-        created_at: string | null;
-        filename: string | null;
-        thumbnail: string | null;
-    };
+    attachment: any;
 
     status: string;
 
@@ -39,12 +32,22 @@ export default function PetitionCard(props: {
         <Card className={''}>
             <CardHeader className={''}>
                 {/* <Image
-                    src={`http://$CORE_HOSTNAME:12001/static/${props.img}`}
-                    alt={props.title}
-                    className="w-full h-48 object-cover"
+                    src={`${props.attachment.attachment}`.replace(
+                        '$CORE_HOSTNAME',
+                        window.location.hostname,
+                    )}
+                    className="w-full h-full bg-red-500"
+                    alt={props.attachment.filename ?? 'Untitled Petition'}
                     width={300}
                     height={200}
                 /> */}
+                <img
+                    src={`${props.attachment.attachment}`.replace(
+                        '$CORE_HOSTNAME',
+                        window.location.hostname,
+                    )}
+                    className="w-full h-full bg-red-500"
+                />
                 <CardTitle>
                     <div
                         className={

--- a/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
@@ -31,13 +31,15 @@ export default function PetitionCard(props: {
     return (
         <Card className={''}>
             <CardHeader className={''}>
-                <img
-                    src={`${props.attachment.attachment}`.replace(
-                        '$CORE_HOSTNAME',
-                        window.location.hostname,
-                    )}
-                    className="w-full h-full bg-red-500 rounded-lg"
-                />
+                {props.attachment.attachment && (
+                    <img
+                        src={`${props.attachment.attachment}`.replace(
+                            '$CORE_HOSTNAME',
+                            window.location.hostname,
+                        )}
+                        className="w-full h-full bg-red-500 rounded-lg"
+                    />
+                )}
                 <CardTitle>
                     <div>
                         <Link

--- a/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionCard.tsx
@@ -5,6 +5,7 @@ import {useAuthState} from '@/auth/token-manager';
 import {formatDate} from '@/lib/date';
 import {useRouter} from 'next/navigation';
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default function PetitionCard(props: {
     id: string;
@@ -13,6 +14,14 @@ export default function PetitionCard(props: {
     date: Date;
     target: string;
     title: string;
+    attachment: {
+        id: string;
+        type: string;
+        attachment: string | null;
+        created_at: string | null;
+        filename: string | null;
+        thumbnail: string | null;
+    };
 
     status: string;
 
@@ -29,6 +38,13 @@ export default function PetitionCard(props: {
     return (
         <Card className={''}>
             <CardHeader className={''}>
+                {/* <Image
+                    src={`http://$CORE_HOSTNAME:12001/static/${props.img}`}
+                    alt={props.title}
+                    className="w-full h-48 object-cover"
+                    width={300}
+                    height={200}
+                /> */}
                 <CardTitle>
                     <div
                         className={

--- a/apps/jonogon-web-next/src/app/components/PetitionList.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionList.tsx
@@ -56,18 +56,7 @@ const PetitionList = () => {
                             status={p.data.status}
                             name={p.extras.user.name ?? ''}
                             title={p.data.title ?? 'Untitled Petition'}
-                            attachment={
-                                typeof p.data.attachment === 'string'
-                                    ? p.data.attachment
-                                    : {
-                                          id: '',
-                                          type: '',
-                                          attachment: null,
-                                          created_at: null,
-                                          filename: null,
-                                          thumbnail: null,
-                                      }
-                            }
+                            attachment={p.data.attachment ?? ''}
                             date={new Date(p.data.submitted_at ?? '1970-01-01')}
                             target={p.data.target ?? 'Some Ministry'}
                             key={p.data.id ?? 0}

--- a/apps/jonogon-web-next/src/app/components/PetitionList.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionList.tsx
@@ -9,6 +9,7 @@ import {
 import PetitionCard from './PetitionCard';
 import {trpc} from '@/trpc';
 import {usePathname, useRouter, useSearchParams} from 'next/navigation';
+import { useEffect } from 'react';
 
 const PetitionList = () => {
     const params = useSearchParams();
@@ -39,6 +40,10 @@ const PetitionList = () => {
 
         router.push(`${pathname}?${nextParams}`);
     };
+
+    useEffect(() => {
+        console.log(petitions);
+    }, [petitions]);
 
     return (
         <div>

--- a/apps/jonogon-web-next/src/app/components/PetitionList.tsx
+++ b/apps/jonogon-web-next/src/app/components/PetitionList.tsx
@@ -9,7 +9,6 @@ import {
 import PetitionCard from './PetitionCard';
 import {trpc} from '@/trpc';
 import {usePathname, useRouter, useSearchParams} from 'next/navigation';
-import { useEffect } from 'react';
 
 const PetitionList = () => {
     const params = useSearchParams();
@@ -41,10 +40,6 @@ const PetitionList = () => {
         router.push(`${pathname}?${nextParams}`);
     };
 
-    useEffect(() => {
-        console.log(petitions);
-    }, [petitions]);
-
     return (
         <div>
             <div
@@ -61,6 +56,18 @@ const PetitionList = () => {
                             status={p.data.status}
                             name={p.extras.user.name ?? ''}
                             title={p.data.title ?? 'Untitled Petition'}
+                            attachment={
+                                typeof p.data.attachment === 'string'
+                                    ? p.data.attachment
+                                    : {
+                                          id: '',
+                                          type: '',
+                                          attachment: null,
+                                          created_at: null,
+                                          filename: null,
+                                          thumbnail: null,
+                                      }
+                            }
                             date={new Date(p.data.submitted_at ?? '1970-01-01')}
                             target={p.data.target ?? 'Some Ministry'}
                             key={p.data.id ?? 0}


### PR DESCRIPTION
# Pull Request: Add Images in the Preview of the Petition Card
## Related Issue
- Closes #26 

## Description
This PR addresses issue #26 by adding the first image of the uploaded media as a default preview image for the "dabi" or "petition" cards. This enhancement aims to provide users with a visual context of the petition, making it easier to understand the problem being addressed.

## Changes Made
- Updated the "dabi" card component to include the first image from the uploaded media as a preview.
- Ensured that the image is displayed correctly on both desktop and mobile views.

## Screenshots
### Existing "Dabi" Card Preview
![Screenshot 2024-08-22 at 9 06 21 AM](https://github.com/user-attachments/assets/0913f8f7-201d-4932-bd53-038139644334)

### After Changes
![Screenshot 2024-08-22 at 9 08 18 AM](https://github.com/user-attachments/assets/fd36603b-5d5e-486e-9773-b9907fbafc67)


