### PR TITLE
Implement Soft Deletion

### DIFF
--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
@@ -300,6 +300,51 @@ export const removeAttachment = protectedProcedure
         };
     });
 
+export const softDeletePetition = protectedProcedure
+    .input(
+        z.object({
+            id: z.number(),
+        }),
+    )
+    .mutation(async ({input, ctx}) => {
+        // Check if the petition exists
+        const petition = await ctx.services.postgresQueryBuilder
+            .selectFrom('petitions')
+            .selectAll()
+            .where('id', '=', `${input.id}`)
+            .executeTakeFirst();
+
+        if (!petition) {
+            throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: 'petition-not-found',
+            });
+        }
+
+        // Check if the user is authorized to delete the petition
+        if (
+            `${petition.created_by}` !== `${ctx.auth.user_id}` &&
+            !ctx.auth.is_user_admin
+        ) {
+            throw new TRPCError({
+                code: 'UNAUTHORIZED',
+                message: 'not-your-petition',
+            });
+        }
+
+        await ctx.services.postgresQueryBuilder
+            .updateTable('petitions')
+            .set({
+                deleted_at: new Date(),
+            })
+            .where('id', '=', `${input.id}`)
+            .executeTakeFirst();
+
+        return {
+            message: 'petition-soft-deleted',
+        };
+    });
+
 export const remove = protectedProcedure
     .input(
         z.object({

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
@@ -42,6 +42,7 @@ export const getPetition = publicProcedure
                 'petition_votes.vote as user_vote',
             ])
             .where('petitions.id', '=', input.id)
+            .where('petitions.deleted_at', 'is', null)
             .executeTakeFirst();
 
         if (!result) {

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -22,6 +22,7 @@ export const listPetitions = publicProcedure
                         scope(
                             db
                                 .selectFrom('petitions')
+                                .where('deleted_at', 'is', null)
                                 .leftJoin('petition_votes as upvotes', (join) =>
                                     join
                                         .onRef(
@@ -156,6 +157,7 @@ export const listPetitions = publicProcedure
                         'location',
                         'target',
                         'created_at',
+                        'deleted_at',
                         'submitted_at',
                         'rejected_at',
                         'rejection_reason',

--- a/apps/jonogon-core/src/api/trpc/routers/petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/routers/petitions.mts
@@ -12,6 +12,7 @@ import {
     removeAttachment,
     submitPetition,
     updatePetition,
+    softDeletePetition,
 } from '../procedures/petitions/crud.mjs';
 import {listPetitions} from '../procedures/petitions/listing/list-petitions.mjs';
 import {listPendingPetitionRequests} from '../procedures/petitions/listing/pending-petition-requests.mjs';
@@ -28,6 +29,7 @@ export const petitionRouter = router({
     submit: submitPetition,
     removeAttachment: removeAttachment,
 
+    softDeletePetition: softDeletePetition,
     remove: remove,
 
     // Skibidi

--- a/apps/jonogon-core/src/db/postgres/types.mts
+++ b/apps/jonogon-core/src/db/postgres/types.mts
@@ -25,6 +25,7 @@ export interface Petitions {
   approved_at: Timestamp | null;
   created_at: Generated<Timestamp>;
   created_by: Int8;
+  deleted_at: Timestamp | null;
   description: string | null;
   formalized_at: Timestamp | null;
   formalized_by: Int8 | null;

--- a/apps/jonogon-web-next/package.json
+++ b/apps/jonogon-web-next/package.json
@@ -16,6 +16,7 @@
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18",
+    "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",

--- a/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
@@ -13,6 +13,18 @@ import z from 'zod';
 import {Label} from '@/components/ui/label';
 import {Input} from '@/components/ui/input';
 import {Button} from '@/components/ui/button';
+import {toast} from '@/components/ui/use-toast';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 export default function EditPetition() {
     const {get: getToken} = useTokenManager();
@@ -109,6 +121,26 @@ export default function EditPetition() {
         });
     };
 
+    const softDeleteMutation = trpc.petitions.softDeletePetition.useMutation({
+        onSuccess: () => {
+            // Show success message
+            toast({
+                title: 'Success',
+                description: 'Petition has been successfully deleted.',
+                variant: 'destructive',
+            });
+
+            // Redirect to home page after a short delay
+            setTimeout(() => {
+                router.push('/?type=own');
+            }, 2000); // Redirect after 2 seconds
+        },
+    });
+
+    const handleSoftDelete = async () => {
+        await softDeleteMutation.mutateAsync({id: Number(petition_id)});
+    };
+
     const {mutate: uploadAttachment} = useMutation({
         mutationFn: async (data: {type: 'image' | 'file'; file: File}) => {
             const search = new URLSearchParams({
@@ -176,12 +208,46 @@ export default function EditPetition() {
 
     return (
         <div className="flex flex-col gap-4 max-w-screen-sm mx-auto pt-5 pb-16 px-4">
-            <h1
-                className={
-                    'text-5xl py-12 md:py-10 font-regular text-stone-600 leading-0'
-                }>
-                {freshValue ? '✊ Create New দাবি' : '✊ Update দাবি'}
-            </h1>
+            <div className="flex flex-col-reverse gap-6 sm:flex-row sm:gap-2 justify-between py-12 md:py-10">
+                <h1
+                    className={
+                        'text-5xl font-regular text-stone-600 leading-0'
+                    }>
+                    {freshValue ? '✊ Create New দাবি' : '✊ Update দাবি'}
+                </h1>
+                {freshValue ? (
+                    ''
+                ) : (
+                    <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                            <Button
+                                size={'lg'}
+                                disabled={isPetitionSaving}
+                                variant={'outline'}>
+                                Delete
+                            </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                            <AlertDialogHeader>
+                                <AlertDialogTitle>
+                                    Are you absolutely sure?
+                                </AlertDialogTitle>
+                                <AlertDialogDescription>
+                                    This action cannot be undone. This will
+                                    permanently delete your account and remove
+                                    your data from our servers.
+                                </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction onClick={handleSoftDelete}>
+                                    Confirm
+                                </AlertDialogAction>
+                            </AlertDialogFooter>
+                        </AlertDialogContent>
+                    </AlertDialog>
+                )}
+            </div>
             <div className="flex flex-col gap-5 py-4">
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="title">

--- a/apps/jonogon-web-next/src/app/petitions/[id]/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/page.tsx
@@ -2,307 +2,462 @@
 
 export const runtime = 'edge';
 
-import {useEffect, useState} from 'react';
-import Markdown from 'react-markdown';
-import {ThumbsDown, ThumbsUp} from 'lucide-react';
-import {Button} from '@/components/ui/button';
-import {ImageCarousel} from './components/ImageCarousel';
+import {useCallback, useEffect, useState} from 'react';
+import {useMutation} from '@tanstack/react-query';
+import {scope} from 'scope-utilities';
+import {TrashIcon} from '@radix-ui/react-icons';
+import {useTokenManager} from '@/auth/token-manager';
+import {useParams, useRouter, useSearchParams} from 'next/navigation';
 import {trpc} from '@/trpc';
-import {useAuthState} from '@/auth/token-manager';
-import {useParams, useRouter} from 'next/navigation';
+import z from 'zod';
+import {Label} from '@/components/ui/label';
+import {Input} from '@/components/ui/input';
+import {Button} from '@/components/ui/button';
+import {toast} from '@/components/ui/use-toast';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
-export default function Petition() {
+export default function EditPetition() {
+    const {get: getToken} = useTokenManager();
     const utils = trpc.useUtils();
 
-    const router = useRouter();
-    const isAuthenticated = useAuthState();
-
-    const {data: selfResponse} = trpc.users.getSelf.useQuery(undefined, {
-        enabled: !!isAuthenticated,
-    });
+    const params = useSearchParams();
 
     const {id: petition_id} = useParams<{id: string}>();
+    const router = useRouter();
 
-    const {data: petition, refetch} = trpc.petitions.get.useQuery({
-        id: petition_id!!,
+    const freshValue = params.get('fresh');
+
+    const [attachmentQueue, setAttachmentQueue] = useState<
+        {
+            type: 'image' | 'attachment';
+            file: File;
+        }[]
+    >([]);
+
+    const removeOne = useCallback(
+        (type: 'image' | 'attachment') => {
+            setAttachmentQueue((queue) => {
+                const lastIndex = queue.findLastIndex(
+                    (attachment) => attachment.type === type,
+                );
+
+                return queue.filter((_attachment, i) => i !== lastIndex);
+            });
+        },
+        [setAttachmentQueue],
+    );
+
+    const {mutate: updatePetition, isLoading: isPetitionSaving} =
+        trpc.petitions.update.useMutation({
+            onSuccess: async () => {
+                await utils.petitions.get.invalidate({id: petition_id});
+                router.push(`/petitions/${petition_id}`);
+            },
+        });
+
+    const {data: petitionRemoteData, isLoading: isPetitionLoading} =
+        trpc.petitions.get.useQuery({
+            id: petition_id!,
+        });
+
+    const [nextPetitionData, setNextPetitionData] = useState<{
+        target?: string;
+        location?: string;
+        title?: string;
+        description?: string;
+    }>({});
+
+    const petitionData = {
+        target:
+            nextPetitionData.target ??
+            petitionRemoteData?.data.target ??
+            undefined,
+        location:
+            nextPetitionData.location ??
+            petitionRemoteData?.data.location ??
+            undefined,
+        title:
+            nextPetitionData.title ??
+            petitionRemoteData?.data.title ??
+            undefined,
+        description:
+            nextPetitionData.description ??
+            petitionRemoteData?.data.description ??
+            undefined,
+    };
+
+    const handleUpdateData = useCallback(
+        (key: keyof typeof nextPetitionData, val: string) => {
+            setNextPetitionData((nextPetitionData) => ({
+                ...nextPetitionData,
+                [key]: val,
+            }));
+        },
+        [setNextPetitionData],
+    );
+
+    const handleUpdatePetition = () => {
+        updatePetition({
+            id: Number(petition_id),
+            data: petitionData,
+        });
+    };
+
+    const handlePetitionSubmission = () => {
+        updatePetition({
+            id: Number(petition_id),
+            data: petitionData,
+            also_submit: true,
+        });
+    };
+
+    const softDeleteMutation = trpc.petitions.softDeletePetition.useMutation({
+        onSuccess: () => {
+            // Show success message
+            toast({
+                title: 'Success',
+                description: 'Petition has been successfully deleted.',
+                variant: 'destructive',
+            });
+
+            // Redirect to home page after a short delay
+            setTimeout(() => {
+                router.push('/?type=own');
+            }, 2000); // Redirect after 2 seconds
+        },
     });
 
-    const [userVote, setUserVote] = useState(0);
+    const handleSoftDelete = async () => {
+        await softDeleteMutation.mutateAsync({id: Number(petition_id)});
+    };
+
+    const {mutate: uploadAttachment} = useMutation({
+        mutationFn: async (data: {type: 'image' | 'file'; file: File}) => {
+            const search = new URLSearchParams({
+                type: data.type,
+                filename: data.file.name,
+            });
+
+            const response = await fetch(
+                process.env.NODE_ENV === 'development'
+                    ? `http://${window.location.hostname}:12001/petitions/${petition_id}/attachments?${search}`
+                    : `https://core.jonogon.org/petitions/${petition_id}/attachments?${search}`,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/octet-stream',
+                        Authorization: `Bearer ${await getToken()}`,
+                    },
+                    body: data.file,
+                },
+            );
+
+            return (await response.json()) as {
+                message: 'image-added' | 'attachment-added';
+            };
+        },
+        onSuccess: async (response) => {
+            if (response.message === 'image-added') {
+                removeOne('image');
+            } else {
+                removeOne('attachment');
+            }
+
+            await utils.petitions.get.invalidate({id: petition_id});
+        },
+    });
 
     useEffect(() => {
-        if (petition) {
-            setUserVote(petition?.extras.user_vote ?? 0);
-        }
-    }, [petition]);
-
-    const thumbsUpMutation = trpc.petitions.vote.useMutation();
-    const thumbsDownMutation = trpc.petitions.vote.useMutation();
-    const clearVoteMutation = trpc.petitions.clearVote.useMutation();
-
-    const clickThumbsUp = async () => {
-        if (!isAuthenticated) {
-            redirectToLoginPage();
+        if (!attachmentQueue.length) {
             return;
         }
 
-        if (userVote == 1) {
-            await clearVoteMutation.mutateAsync({
-                petition_id: petition_id!!,
-            });
-            setUserVote(0);
-        } else {
-            await thumbsUpMutation.mutateAsync({
-                petition_id: petition_id!!,
-                vote: 'up',
-            });
-            setUserVote(1);
-        }
-        refetch();
-    };
+        const attachment = attachmentQueue[attachmentQueue.length - 1];
 
-    const clickThumbsDown = async () => {
-        if (!isAuthenticated) {
-            redirectToLoginPage();
-            return;
-        }
-        
-        if (userVote == -1) {
-            await clearVoteMutation.mutateAsync({
-                petition_id: petition_id!!,
-            });
-            setUserVote(0);
-        } else {
-            await thumbsDownMutation.mutateAsync({
-                petition_id: petition_id!!,
-                vote: 'down',
-            });
-            setUserVote(-1);
-        }
-        refetch();
-    };
+        uploadAttachment({
+            type: attachment.type === 'image' ? 'image' : 'file',
+            file: attachment.file,
+        });
+    }, [attachmentQueue]);
 
-    const redirectToLoginPage = () => {
-        const nextUrl = encodeURIComponent(`/petitions/${petition_id}`);
-        router.push(`/login?next=${nextUrl}`);
-    }
+    const {mutate: removeAttachment} =
+        trpc.petitions.removeAttachment.useMutation({
+            onSuccess: async () => {
+                await utils.petitions.get.invalidate({id: petition_id});
+            },
+        });
 
-    const upvoteCount = petition?.data.petition_upvote_count ?? 0;
-    const downvoteCount = petition?.data.petition_downvote_count ?? 0;
-    const totalVoteCount = upvoteCount + downvoteCount;
-
-    const isOwnPetition =
-        petition &&
-        selfResponse &&
-        `${petition?.data.created_by}` === `${selfResponse?.data.id}`;
-
-    const isAdmin = !!selfResponse?.meta.token.is_user_admin;
-    const isMod = !!selfResponse?.meta.token.is_user_moderator;
-    const status = petition?.data.status ?? 'draft';
-
-    const {mutate: approve} = trpc.petitions.approve.useMutation({
-        onSuccess: async () => {
-            await utils.petitions.get.invalidate({id: petition_id});
-        },
-    });
-
-    const {mutate: reject} = trpc.petitions.reject.useMutation({
-        onSuccess: async () => {
-            await utils.petitions.get.invalidate({id: petition_id});
-        },
-    });
-
-    const {mutate: formalize} = trpc.petitions.formalize.useMutation({
-        onSuccess: async () => {
-            await utils.petitions.get.invalidate({id: petition_id});
-        },
-    });
+    const isValid = z
+        .object({
+            title: z.string().min(12),
+            target: z.string().min(6),
+            location: z.string().min(6),
+            description: z.string().optional(),
+        })
+        .safeParse(petitionData).success;
 
     return (
-        <>
-            <div className="max-w-screen-sm mx-auto px-4 pt-12 mb-28 flex flex-col gap-4">
-                {isOwnPetition || isMod || isAdmin ? (
-                    <div
-                        className={
-                            'bg-border px-3 py-2 rounded-lg flex justify-end items-center gap-2'
-                        }>
-                        {status === 'rejected' ? (
-                            <div className={'flex-1'}>
-                                <div
-                                    className={
-                                        'font-bold text-red-500 text-sm'
-                                    }>
-                                    Your petition was rejected.
-                                </div>
-                                <div>
-                                    {petition?.data.rejection_reason ?? ''}
-                                </div>
-                            </div>
-                        ) : null}
-                        {isMod || isAdmin ? (
-                            <div className={'flex flex-row gap-2 items-center'}>
-                                {status === 'submitted' ? (
-                                    <span className={'text-sm'}>
-                                        NOT MODERATED YET
-                                    </span>
-                                ) : null}
-                                {status === 'approved' ? (
-                                    <Button
-                                        size={'sm'}
-                                        intent={'success'}
-                                        onClick={() =>
-                                            window.confirm(
-                                                'You sure you wanna elevate to this some next level shizz?',
-                                            ) &&
-                                            formalize({
-                                                petition_id:
-                                                    Number(petition_id),
-                                            })
-                                        }>
-                                        Formalize
-                                    </Button>
-                                ) : null}
-                                {status === 'submitted' ||
-                                status === 'rejected' ? (
-                                    <Button
-                                        size={'sm'}
-                                        intent={'success'}
-                                        onClick={() =>
-                                            window.confirm(
-                                                'You sure you wanna approve?',
-                                            ) &&
-                                            approve({
-                                                petition_id:
-                                                    Number(petition_id),
-                                            })
-                                        }>
-                                        Approve
-                                    </Button>
-                                ) : null}
-                                {status !== 'rejected' && status !== 'draft' ? (
-                                    <Button
-                                        size={'sm'}
-                                        intent={'default'}
-                                        onClick={() => {
-                                            const rejectionReason =
-                                                window.prompt(
-                                                    'Why you rejecting? (leave empty to cancel)',
-                                                );
-
-                                            rejectionReason &&
-                                                reject({
-                                                    petition_id:
-                                                        Number(petition_id),
-                                                    reason: rejectionReason,
-                                                });
-                                        }}>
-                                        Reject
-                                    </Button>
-                                ) : null}
-                            </div>
-                        ) : null}
-
-                        {isOwnPetition || isAdmin ? (
-                            <Button
-                                size={'sm'}
-                                onClick={() =>
-                                    router.push(
-                                        `/petitions/${petition_id}/edit`,
-                                    )
-                                }>
-                                Edit দাবি
-                            </Button>
-                        ) : null}
-                    </div>
-                ) : null}
-
-                <div className={'space-x-1 text-lg text-stone-500'}>
-                    <time
-                        dateTime={
-                            petition?.data.created_at
-                                ? new Date(
-                                      petition.data.created_at,
-                                  ).toISOString()
-                                : ''
-                        }
-                        suppressHydrationWarning
-                    >
-                        {petition?.data.created_at
-                            ? new Date(
-                                  petition.data.created_at,
-                              ).toLocaleDateString('en-GB', {
-                                  year: 'numeric',
-                                  month: 'long',
-                                  day: 'numeric',
-                              })
-                            : 'UNKNOWN DATE'}
-                        {','}
-                    </time>
-                    <span className={'italic font-semibold'}>
-                        {petition?.extras.user.name ?? ''}
-                    </span>
-                    <span>—</span>
-                    <span>To</span>
-                    <span className={'italic font-semibold'}>
-                        {petition?.data.target ?? 'UNKNOWN MINISTRY'}.
-                    </span>
-                </div>
-                <h1 className="text-4xl font-bold font-serif">
-                    {petition?.data.title ?? 'Untiled Petition'}
+        <div className="flex flex-col gap-4 max-w-screen-sm mx-auto pt-5 pb-16 px-4">
+            <div className="flex flex-col-reverse gap-6 sm:flex-row sm:gap-2 justify-between py-12 md:py-10">
+                <h1
+                    className={
+                        'text-5xl font-regular text-stone-600 leading-0'
+                    }>
+                    {freshValue ? '✊ Create New দাবি' : '✊ Update দাবি'}
                 </h1>
-                <div className="space-x-2 border-l-4 pl-4 text-neutral-700 text-lg">
-                    <span>It affects</span>
-                    <span className={'italic font-semibold'}>
-                        {petition?.data.location ?? 'SOMEONE, SOMEWHERE'}.
-                    </span>
-                </div>
-                <ImageCarousel />
-                {petition?.data.description && (
-                    <Markdown>
-                        {petition.data.description ?? 'No description yet.'}
-                    </Markdown>
+                {freshValue ? (
+                    ''
+                ) : (
+                    <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                            <Button
+                                size={'lg'}
+                                disabled={isPetitionSaving}
+                                variant={'outline'}>
+                                Delete
+                            </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                            <AlertDialogHeader>
+                                <AlertDialogTitle>
+                                    Are you absolutely sure?
+                                </AlertDialogTitle>
+                                <AlertDialogDescription>
+                                    This action cannot be undone. This will
+                                    permanently delete your account and remove
+                                    your data from our servers.
+                                </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction onClick={handleSoftDelete}>
+                                    Confirm
+                                </AlertDialogAction>
+                            </AlertDialogFooter>
+                        </AlertDialogContent>
+                    </AlertDialog>
                 )}
             </div>
-            <div className="fixed bottom-0 left-0 w-full py-2 bg-background z-20 px-4">
-                <div
-                    className={
-                        'w-full mx-auto max-w-screen-sm flex flex-row space-x-2'
-                    }>
-                    <Button
-                        variant={
-                            userVote === 1 || userVote === 0
-                                ? 'default'
-                                : 'outline'
+            <div className="flex flex-col gap-5 py-4">
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="title">
+                        <div className={'font-bold text-lg'}>Title *</div>
+                        <div className={'text-stone-500'}>
+                            আপনার আবেদনের শিরোনাম লিখুন
+                        </div>
+                    </Label>
+                    <Input
+                        className="bg-card text-card-foreground text-2xl py-7"
+                        id="title"
+                        value={petitionData.title ?? ''}
+                        onChange={(e) =>
+                            handleUpdateData('title', e.target.value)
                         }
-                        intent={'success'}
+                        placeholder="Ex: Make Primary Education Better"
+                    />
+                </div>
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="target">
+                        <div className={'font-bold text-lg'}>
+                            Who are you petitioning to? *
+                        </div>
+                        <div className={'text-stone-500'}>
+                            আপনি কার কাছে দাবি করছেন?
+                        </div>
+                    </Label>
+                    <Input
+                        className="bg-card text-card-foreground"
+                        id="target"
+                        value={petitionData.target ?? ''}
+                        onChange={(e) =>
+                            handleUpdateData('target', e.target.value)
+                        }
+                        placeholder="Ex: Minister, Ministry, Department, Politician, Prime Minister"
+                    />
+                </div>
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="target">
+                        <div className={'font-bold text-lg'}>
+                            Area it affects *
+                        </div>
+                        <div className={'text-stone-500'}>
+                            কন এলাকার মানুষের জন্য প্রযোজ্য?
+                        </div>
+                    </Label>
+                    <Input
+                        className="bg-card text-card-foreground"
+                        id="target"
+                        value={petitionData.location ?? ''}
+                        onChange={(e) =>
+                            handleUpdateData('location', e.target.value)
+                        }
+                        placeholder="Ex: Entire Bangladesh"
+                    />
+                </div>
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="pictures">
+                        <div className={'font-bold text-lg'}>
+                            Pictures{' '}
+                            <span
+                                className={'font-light italic text-stone-600'}>
+                                (optional)
+                            </span>
+                        </div>
+                        <div className={'text-stone-500'}>
+                            কিছু ছবি upload করতে পারেন
+                        </div>
+                    </Label>
+                    <div className={'flex flex-row flex-wrap gap-2'}>
+                        <div
+                            className={
+                                'flex justify-center items-center border-4 w-24 h-20 rounded-lg relative bg-card hover:bg-card/30 cursor-pointer'
+                            }>
+                            <span
+                                className={
+                                    'text-5xl text-stone-400 drop-shadow-sm cursor-pointer'
+                                }>
+                                +
+                            </span>
+                            <input
+                                id={'pictures'}
+                                type={'file'}
+                                multiple
+                                accept={'image/*'}
+                                className={
+                                    'absolute top-0 left-0 w-full h-full opacity-0 cursor-pointer'
+                                }
+                                onChange={(ev) => {
+                                    setAttachmentQueue((queue) => [
+                                        ...queue,
+                                        ...scope(ev.target.files).let(
+                                            (files) => {
+                                                if (!files) {
+                                                    return [];
+                                                }
+
+                                                const attachments = [];
+
+                                                for (
+                                                    let i = 0;
+                                                    i < files.length;
+                                                    i++
+                                                ) {
+                                                    const file = files.item(i);
+
+                                                    if (!file) {
+                                                        continue;
+                                                    }
+
+                                                    attachments.push({
+                                                        type: 'image' as const,
+                                                        file: file,
+                                                    });
+                                                }
+
+                                                return attachments;
+                                            },
+                                        ),
+                                    ]);
+                                }}
+                            />
+                        </div>
+
+                        {attachmentQueue
+                            .filter((attachment) => attachment.type === 'image')
+                            .map((attachment, i) => (
+                                <div
+                                    key={i}
+                                    className={
+                                        'flex justify-center items-center border-4 w-24 h-20 rounded-lg'
+                                    }>
+                                    <div
+                                        className={
+                                            'animate-spin border-4 border-b-transparent border-l-transparent border-red-500 w-8 h-8 rounded-full'
+                                        }></div>
+                                </div>
+                            ))}
+
+                        {petitionRemoteData?.data?.attachments
+                            .filter((attachment) => attachment.type === 'image')
+                            .map((attachment) => (
+                                <div
+                                    key={attachment.id}
+                                    className={
+                                        'flex justify-center items-center border-4 w-24 h-20 rounded-lg bg-black relative'
+                                    }>
+                                    <img
+                                        src={attachment.thumbnail!!.replace(
+                                            '$CORE_HOSTNAME',
+                                            window.location.hostname,
+                                        )}
+                                        alt={attachment.filename}
+                                        className={
+                                            'w-full h-full object-contain object-center'
+                                        }
+                                    />
+                                    <button
+                                        className={
+                                            'absolute bottom-1 right-1 bg-red-500/90 text-sm hover:bg-red-600 p-2 rounded-sm'
+                                        }
+                                        onClick={() =>
+                                            removeAttachment({
+                                                petition_id: Number(
+                                                    petition_id ?? '0',
+                                                ),
+                                                attachment_id: Number(
+                                                    attachment.id,
+                                                ),
+                                            })
+                                        }>
+                                        <TrashIcon />
+                                    </button>
+                                </div>
+                            ))}
+                    </div>
+                </div>
+                <div className="flex flex-col gap-2">
+                    <Label>
+                        <div className={'font-bold text-lg'}>
+                            Petition Details
+                        </div>
+                        <div className={'text-stone-500'}>বিস্তারিত লিখুন</div>
+                    </Label>
+                    <textarea
+                        className={'font-mono p-3 h-48'}
+                        placeholder={'Enter Details Here...'}
+                        value={petitionData.description ?? ''}
+                        onChange={(e) =>
+                            handleUpdateData('description', e.target.value)
+                        }></textarea>
+                </div>
+                <div className={'flex flex-row space-x-2'}>
+                    <Button
+                        className={'flex-1'}
                         size={'lg'}
-                        className="flex-1 w-full"
-                        onClick={clickThumbsUp}>
-                        {status === 'formalized' ? (
-                            <>
-                                <p className="ml-2">{upvoteCount} — VOTE</p>
-                            </>
-                        ) : (
-                            <>
-                                <ThumbsUp size={20} />{' '}
-                                <p className="ml-2">{upvoteCount}</p>
-                            </>
-                        )}
+                        disabled={isPetitionSaving || !isValid}
+                        onClick={handlePetitionSubmission}>
+                        Submit দাবি
                     </Button>
+
                     <Button
-                        variant={
-                            userVote === -1 || userVote === 0
-                                ? 'default'
-                                : 'outline'
-                        }
-                        intent={'default'}
-                        className="flex-1 w-full"
+                        variant={isValid ? 'outline' : 'default'}
                         size={'lg'}
-                        onClick={clickThumbsDown}>
-                        <ThumbsDown size={20} />{' '}
-                        <p className="ml-2">{downvoteCount}</p>
+                        disabled={isPetitionSaving}
+                        onClick={handleUpdatePetition}>
+                        Save Draft
                     </Button>
                 </div>
             </div>
-        </>
+        </div>
     );
 }

--- a/apps/jonogon-web-next/src/app/petitions/[id]/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/page.tsx
@@ -2,462 +2,306 @@
 
 export const runtime = 'edge';
 
-import {useCallback, useEffect, useState} from 'react';
-import {useMutation} from '@tanstack/react-query';
-import {scope} from 'scope-utilities';
-import {TrashIcon} from '@radix-ui/react-icons';
-import {useTokenManager} from '@/auth/token-manager';
-import {useParams, useRouter, useSearchParams} from 'next/navigation';
-import {trpc} from '@/trpc';
-import z from 'zod';
-import {Label} from '@/components/ui/label';
-import {Input} from '@/components/ui/input';
+import {useEffect, useState} from 'react';
+import Markdown from 'react-markdown';
+import {ThumbsDown, ThumbsUp} from 'lucide-react';
 import {Button} from '@/components/ui/button';
-import {toast} from '@/components/ui/use-toast';
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-    AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import {ImageCarousel} from './components/ImageCarousel';
+import {trpc} from '@/trpc';
+import {useAuthState} from '@/auth/token-manager';
+import {useParams, useRouter} from 'next/navigation';
 
-export default function EditPetition() {
-    const {get: getToken} = useTokenManager();
+export default function Petition() {
     const utils = trpc.useUtils();
 
-    const params = useSearchParams();
-
-    const {id: petition_id} = useParams<{id: string}>();
     const router = useRouter();
+    const isAuthenticated = useAuthState();
 
-    const freshValue = params.get('fresh');
-
-    const [attachmentQueue, setAttachmentQueue] = useState<
-        {
-            type: 'image' | 'attachment';
-            file: File;
-        }[]
-    >([]);
-
-    const removeOne = useCallback(
-        (type: 'image' | 'attachment') => {
-            setAttachmentQueue((queue) => {
-                const lastIndex = queue.findLastIndex(
-                    (attachment) => attachment.type === type,
-                );
-
-                return queue.filter((_attachment, i) => i !== lastIndex);
-            });
-        },
-        [setAttachmentQueue],
-    );
-
-    const {mutate: updatePetition, isLoading: isPetitionSaving} =
-        trpc.petitions.update.useMutation({
-            onSuccess: async () => {
-                await utils.petitions.get.invalidate({id: petition_id});
-                router.push(`/petitions/${petition_id}`);
-            },
-        });
-
-    const {data: petitionRemoteData, isLoading: isPetitionLoading} =
-        trpc.petitions.get.useQuery({
-            id: petition_id!,
-        });
-
-    const [nextPetitionData, setNextPetitionData] = useState<{
-        target?: string;
-        location?: string;
-        title?: string;
-        description?: string;
-    }>({});
-
-    const petitionData = {
-        target:
-            nextPetitionData.target ??
-            petitionRemoteData?.data.target ??
-            undefined,
-        location:
-            nextPetitionData.location ??
-            petitionRemoteData?.data.location ??
-            undefined,
-        title:
-            nextPetitionData.title ??
-            petitionRemoteData?.data.title ??
-            undefined,
-        description:
-            nextPetitionData.description ??
-            petitionRemoteData?.data.description ??
-            undefined,
-    };
-
-    const handleUpdateData = useCallback(
-        (key: keyof typeof nextPetitionData, val: string) => {
-            setNextPetitionData((nextPetitionData) => ({
-                ...nextPetitionData,
-                [key]: val,
-            }));
-        },
-        [setNextPetitionData],
-    );
-
-    const handleUpdatePetition = () => {
-        updatePetition({
-            id: Number(petition_id),
-            data: petitionData,
-        });
-    };
-
-    const handlePetitionSubmission = () => {
-        updatePetition({
-            id: Number(petition_id),
-            data: petitionData,
-            also_submit: true,
-        });
-    };
-
-    const softDeleteMutation = trpc.petitions.softDeletePetition.useMutation({
-        onSuccess: () => {
-            // Show success message
-            toast({
-                title: 'Success',
-                description: 'Petition has been successfully deleted.',
-                variant: 'destructive',
-            });
-
-            // Redirect to home page after a short delay
-            setTimeout(() => {
-                router.push('/?type=own');
-            }, 2000); // Redirect after 2 seconds
-        },
+    const {data: selfResponse} = trpc.users.getSelf.useQuery(undefined, {
+        enabled: !!isAuthenticated,
     });
 
-    const handleSoftDelete = async () => {
-        await softDeleteMutation.mutateAsync({id: Number(petition_id)});
+    const {id: petition_id} = useParams<{id: string}>();
+
+    const {data: petition, refetch} = trpc.petitions.get.useQuery({
+        id: petition_id!!,
+    });
+
+    const [userVote, setUserVote] = useState(0);
+
+    useEffect(() => {
+        if (petition) {
+            setUserVote(petition?.extras.user_vote ?? 0);
+        }
+    }, [petition]);
+
+    const thumbsUpMutation = trpc.petitions.vote.useMutation();
+    const thumbsDownMutation = trpc.petitions.vote.useMutation();
+    const clearVoteMutation = trpc.petitions.clearVote.useMutation();
+
+    const clickThumbsUp = async () => {
+        if (!isAuthenticated) {
+            redirectToLoginPage();
+            return;
+        }
+
+        if (userVote == 1) {
+            await clearVoteMutation.mutateAsync({
+                petition_id: petition_id!!,
+            });
+            setUserVote(0);
+        } else {
+            await thumbsUpMutation.mutateAsync({
+                petition_id: petition_id!!,
+                vote: 'up',
+            });
+            setUserVote(1);
+        }
+        refetch();
     };
 
-    const {mutate: uploadAttachment} = useMutation({
-        mutationFn: async (data: {type: 'image' | 'file'; file: File}) => {
-            const search = new URLSearchParams({
-                type: data.type,
-                filename: data.file.name,
+    const clickThumbsDown = async () => {
+        if (!isAuthenticated) {
+            redirectToLoginPage();
+            return;
+        }
+
+        if (userVote == -1) {
+            await clearVoteMutation.mutateAsync({
+                petition_id: petition_id!!,
             });
+            setUserVote(0);
+        } else {
+            await thumbsDownMutation.mutateAsync({
+                petition_id: petition_id!!,
+                vote: 'down',
+            });
+            setUserVote(-1);
+        }
+        refetch();
+    };
 
-            const response = await fetch(
-                process.env.NODE_ENV === 'development'
-                    ? `http://${window.location.hostname}:12001/petitions/${petition_id}/attachments?${search}`
-                    : `https://core.jonogon.org/petitions/${petition_id}/attachments?${search}`,
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/octet-stream',
-                        Authorization: `Bearer ${await getToken()}`,
-                    },
-                    body: data.file,
-                },
-            );
+    const redirectToLoginPage = () => {
+        const nextUrl = encodeURIComponent(`/petitions/${petition_id}`);
+        router.push(`/login?next=${nextUrl}`);
+    };
 
-            return (await response.json()) as {
-                message: 'image-added' | 'attachment-added';
-            };
-        },
-        onSuccess: async (response) => {
-            if (response.message === 'image-added') {
-                removeOne('image');
-            } else {
-                removeOne('attachment');
-            }
+    const upvoteCount = petition?.data.petition_upvote_count ?? 0;
+    const downvoteCount = petition?.data.petition_downvote_count ?? 0;
+    const totalVoteCount = upvoteCount + downvoteCount;
 
+    const isOwnPetition =
+        petition &&
+        selfResponse &&
+        `${petition?.data.created_by}` === `${selfResponse?.data.id}`;
+
+    const isAdmin = !!selfResponse?.meta.token.is_user_admin;
+    const isMod = !!selfResponse?.meta.token.is_user_moderator;
+    const status = petition?.data.status ?? 'draft';
+
+    const {mutate: approve} = trpc.petitions.approve.useMutation({
+        onSuccess: async () => {
             await utils.petitions.get.invalidate({id: petition_id});
         },
     });
 
-    useEffect(() => {
-        if (!attachmentQueue.length) {
-            return;
-        }
+    const {mutate: reject} = trpc.petitions.reject.useMutation({
+        onSuccess: async () => {
+            await utils.petitions.get.invalidate({id: petition_id});
+        },
+    });
 
-        const attachment = attachmentQueue[attachmentQueue.length - 1];
-
-        uploadAttachment({
-            type: attachment.type === 'image' ? 'image' : 'file',
-            file: attachment.file,
-        });
-    }, [attachmentQueue]);
-
-    const {mutate: removeAttachment} =
-        trpc.petitions.removeAttachment.useMutation({
-            onSuccess: async () => {
-                await utils.petitions.get.invalidate({id: petition_id});
-            },
-        });
-
-    const isValid = z
-        .object({
-            title: z.string().min(12),
-            target: z.string().min(6),
-            location: z.string().min(6),
-            description: z.string().optional(),
-        })
-        .safeParse(petitionData).success;
+    const {mutate: formalize} = trpc.petitions.formalize.useMutation({
+        onSuccess: async () => {
+            await utils.petitions.get.invalidate({id: petition_id});
+        },
+    });
 
     return (
-        <div className="flex flex-col gap-4 max-w-screen-sm mx-auto pt-5 pb-16 px-4">
-            <div className="flex flex-col-reverse gap-6 sm:flex-row sm:gap-2 justify-between py-12 md:py-10">
-                <h1
-                    className={
-                        'text-5xl font-regular text-stone-600 leading-0'
-                    }>
-                    {freshValue ? '✊ Create New দাবি' : '✊ Update দাবি'}
-                </h1>
-                {freshValue ? (
-                    ''
-                ) : (
-                    <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                            <Button
-                                size={'lg'}
-                                disabled={isPetitionSaving}
-                                variant={'outline'}>
-                                Delete
-                            </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                            <AlertDialogHeader>
-                                <AlertDialogTitle>
-                                    Are you absolutely sure?
-                                </AlertDialogTitle>
-                                <AlertDialogDescription>
-                                    This action cannot be undone. This will
-                                    permanently delete your account and remove
-                                    your data from our servers.
-                                </AlertDialogDescription>
-                            </AlertDialogHeader>
-                            <AlertDialogFooter>
-                                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                                <AlertDialogAction onClick={handleSoftDelete}>
-                                    Confirm
-                                </AlertDialogAction>
-                            </AlertDialogFooter>
-                        </AlertDialogContent>
-                    </AlertDialog>
-                )}
-            </div>
-            <div className="flex flex-col gap-5 py-4">
-                <div className="flex flex-col gap-2">
-                    <Label htmlFor="title">
-                        <div className={'font-bold text-lg'}>Title *</div>
-                        <div className={'text-stone-500'}>
-                            আপনার আবেদনের শিরোনাম লিখুন
-                        </div>
-                    </Label>
-                    <Input
-                        className="bg-card text-card-foreground text-2xl py-7"
-                        id="title"
-                        value={petitionData.title ?? ''}
-                        onChange={(e) =>
-                            handleUpdateData('title', e.target.value)
-                        }
-                        placeholder="Ex: Make Primary Education Better"
-                    />
-                </div>
-                <div className="flex flex-col gap-2">
-                    <Label htmlFor="target">
-                        <div className={'font-bold text-lg'}>
-                            Who are you petitioning to? *
-                        </div>
-                        <div className={'text-stone-500'}>
-                            আপনি কার কাছে দাবি করছেন?
-                        </div>
-                    </Label>
-                    <Input
-                        className="bg-card text-card-foreground"
-                        id="target"
-                        value={petitionData.target ?? ''}
-                        onChange={(e) =>
-                            handleUpdateData('target', e.target.value)
-                        }
-                        placeholder="Ex: Minister, Ministry, Department, Politician, Prime Minister"
-                    />
-                </div>
-                <div className="flex flex-col gap-2">
-                    <Label htmlFor="target">
-                        <div className={'font-bold text-lg'}>
-                            Area it affects *
-                        </div>
-                        <div className={'text-stone-500'}>
-                            কন এলাকার মানুষের জন্য প্রযোজ্য?
-                        </div>
-                    </Label>
-                    <Input
-                        className="bg-card text-card-foreground"
-                        id="target"
-                        value={petitionData.location ?? ''}
-                        onChange={(e) =>
-                            handleUpdateData('location', e.target.value)
-                        }
-                        placeholder="Ex: Entire Bangladesh"
-                    />
-                </div>
-                <div className="flex flex-col gap-2">
-                    <Label htmlFor="pictures">
-                        <div className={'font-bold text-lg'}>
-                            Pictures{' '}
-                            <span
-                                className={'font-light italic text-stone-600'}>
-                                (optional)
-                            </span>
-                        </div>
-                        <div className={'text-stone-500'}>
-                            কিছু ছবি upload করতে পারেন
-                        </div>
-                    </Label>
-                    <div className={'flex flex-row flex-wrap gap-2'}>
-                        <div
-                            className={
-                                'flex justify-center items-center border-4 w-24 h-20 rounded-lg relative bg-card hover:bg-card/30 cursor-pointer'
-                            }>
-                            <span
-                                className={
-                                    'text-5xl text-stone-400 drop-shadow-sm cursor-pointer'
-                                }>
-                                +
-                            </span>
-                            <input
-                                id={'pictures'}
-                                type={'file'}
-                                multiple
-                                accept={'image/*'}
-                                className={
-                                    'absolute top-0 left-0 w-full h-full opacity-0 cursor-pointer'
-                                }
-                                onChange={(ev) => {
-                                    setAttachmentQueue((queue) => [
-                                        ...queue,
-                                        ...scope(ev.target.files).let(
-                                            (files) => {
-                                                if (!files) {
-                                                    return [];
-                                                }
-
-                                                const attachments = [];
-
-                                                for (
-                                                    let i = 0;
-                                                    i < files.length;
-                                                    i++
-                                                ) {
-                                                    const file = files.item(i);
-
-                                                    if (!file) {
-                                                        continue;
-                                                    }
-
-                                                    attachments.push({
-                                                        type: 'image' as const,
-                                                        file: file,
-                                                    });
-                                                }
-
-                                                return attachments;
-                                            },
-                                        ),
-                                    ]);
-                                }}
-                            />
-                        </div>
-
-                        {attachmentQueue
-                            .filter((attachment) => attachment.type === 'image')
-                            .map((attachment, i) => (
+        <>
+            <div className="max-w-screen-sm mx-auto px-4 pt-12 mb-28 flex flex-col gap-4">
+                {isOwnPetition || isMod || isAdmin ? (
+                    <div
+                        className={
+                            'bg-border px-3 py-2 rounded-lg flex justify-end items-center gap-2'
+                        }>
+                        {status === 'rejected' ? (
+                            <div className={'flex-1'}>
                                 <div
-                                    key={i}
                                     className={
-                                        'flex justify-center items-center border-4 w-24 h-20 rounded-lg'
+                                        'font-bold text-red-500 text-sm'
                                     }>
-                                    <div
-                                        className={
-                                            'animate-spin border-4 border-b-transparent border-l-transparent border-red-500 w-8 h-8 rounded-full'
-                                        }></div>
+                                    Your petition was rejected.
                                 </div>
-                            ))}
-
-                        {petitionRemoteData?.data?.attachments
-                            .filter((attachment) => attachment.type === 'image')
-                            .map((attachment) => (
-                                <div
-                                    key={attachment.id}
-                                    className={
-                                        'flex justify-center items-center border-4 w-24 h-20 rounded-lg bg-black relative'
-                                    }>
-                                    <img
-                                        src={attachment.thumbnail!!.replace(
-                                            '$CORE_HOSTNAME',
-                                            window.location.hostname,
-                                        )}
-                                        alt={attachment.filename}
-                                        className={
-                                            'w-full h-full object-contain object-center'
-                                        }
-                                    />
-                                    <button
-                                        className={
-                                            'absolute bottom-1 right-1 bg-red-500/90 text-sm hover:bg-red-600 p-2 rounded-sm'
-                                        }
+                                <div>
+                                    {petition?.data.rejection_reason ?? ''}
+                                </div>
+                            </div>
+                        ) : null}
+                        {isMod || isAdmin ? (
+                            <div className={'flex flex-row gap-2 items-center'}>
+                                {status === 'submitted' ? (
+                                    <span className={'text-sm'}>
+                                        NOT MODERATED YET
+                                    </span>
+                                ) : null}
+                                {status === 'approved' ? (
+                                    <Button
+                                        size={'sm'}
+                                        intent={'success'}
                                         onClick={() =>
-                                            removeAttachment({
-                                                petition_id: Number(
-                                                    petition_id ?? '0',
-                                                ),
-                                                attachment_id: Number(
-                                                    attachment.id,
-                                                ),
+                                            window.confirm(
+                                                'You sure you wanna elevate to this some next level shizz?',
+                                            ) &&
+                                            formalize({
+                                                petition_id:
+                                                    Number(petition_id),
                                             })
                                         }>
-                                        <TrashIcon />
-                                    </button>
-                                </div>
-                            ))}
-                    </div>
-                </div>
-                <div className="flex flex-col gap-2">
-                    <Label>
-                        <div className={'font-bold text-lg'}>
-                            Petition Details
-                        </div>
-                        <div className={'text-stone-500'}>বিস্তারিত লিখুন</div>
-                    </Label>
-                    <textarea
-                        className={'font-mono p-3 h-48'}
-                        placeholder={'Enter Details Here...'}
-                        value={petitionData.description ?? ''}
-                        onChange={(e) =>
-                            handleUpdateData('description', e.target.value)
-                        }></textarea>
-                </div>
-                <div className={'flex flex-row space-x-2'}>
-                    <Button
-                        className={'flex-1'}
-                        size={'lg'}
-                        disabled={isPetitionSaving || !isValid}
-                        onClick={handlePetitionSubmission}>
-                        Submit দাবি
-                    </Button>
+                                        Formalize
+                                    </Button>
+                                ) : null}
+                                {status === 'submitted' ||
+                                status === 'rejected' ? (
+                                    <Button
+                                        size={'sm'}
+                                        intent={'success'}
+                                        onClick={() =>
+                                            window.confirm(
+                                                'You sure you wanna approve?',
+                                            ) &&
+                                            approve({
+                                                petition_id:
+                                                    Number(petition_id),
+                                            })
+                                        }>
+                                        Approve
+                                    </Button>
+                                ) : null}
+                                {status !== 'rejected' && status !== 'draft' ? (
+                                    <Button
+                                        size={'sm'}
+                                        intent={'default'}
+                                        onClick={() => {
+                                            const rejectionReason =
+                                                window.prompt(
+                                                    'Why you rejecting? (leave empty to cancel)',
+                                                );
 
+                                            rejectionReason &&
+                                                reject({
+                                                    petition_id:
+                                                        Number(petition_id),
+                                                    reason: rejectionReason,
+                                                });
+                                        }}>
+                                        Reject
+                                    </Button>
+                                ) : null}
+                            </div>
+                        ) : null}
+
+                        {isOwnPetition || isAdmin ? (
+                            <Button
+                                size={'sm'}
+                                onClick={() =>
+                                    router.push(
+                                        `/petitions/${petition_id}/edit`,
+                                    )
+                                }>
+                                Edit দাবি
+                            </Button>
+                        ) : null}
+                    </div>
+                ) : null}
+
+                <div className={'space-x-1 text-lg text-stone-500'}>
+                    <time
+                        dateTime={
+                            petition?.data.created_at
+                                ? new Date(
+                                      petition.data.created_at,
+                                  ).toISOString()
+                                : ''
+                        }
+                        suppressHydrationWarning>
+                        {petition?.data.created_at
+                            ? new Date(
+                                  petition.data.created_at,
+                              ).toLocaleDateString('en-GB', {
+                                  year: 'numeric',
+                                  month: 'long',
+                                  day: 'numeric',
+                              })
+                            : 'UNKNOWN DATE'}
+                        {','}
+                    </time>
+                    <span className={'italic font-semibold'}>
+                        {petition?.extras.user.name ?? ''}
+                    </span>
+                    <span>—</span>
+                    <span>To</span>
+                    <span className={'italic font-semibold'}>
+                        {petition?.data.target ?? 'UNKNOWN MINISTRY'}.
+                    </span>
+                </div>
+                <h1 className="text-4xl font-bold font-serif">
+                    {petition?.data.title ?? 'Untiled Petition'}
+                </h1>
+                <div className="space-x-2 border-l-4 pl-4 text-neutral-700 text-lg">
+                    <span>It affects</span>
+                    <span className={'italic font-semibold'}>
+                        {petition?.data.location ?? 'SOMEONE, SOMEWHERE'}.
+                    </span>
+                </div>
+                <ImageCarousel />
+                {petition?.data.description && (
+                    <Markdown>
+                        {petition.data.description ?? 'No description yet.'}
+                    </Markdown>
+                )}
+            </div>
+            <div className="fixed bottom-0 left-0 w-full py-2 bg-background z-20 px-4">
+                <div
+                    className={
+                        'w-full mx-auto max-w-screen-sm flex flex-row space-x-2'
+                    }>
                     <Button
-                        variant={isValid ? 'outline' : 'default'}
+                        variant={
+                            userVote === 1 || userVote === 0
+                                ? 'default'
+                                : 'outline'
+                        }
+                        intent={'success'}
                         size={'lg'}
-                        disabled={isPetitionSaving}
-                        onClick={handleUpdatePetition}>
-                        Save Draft
+                        className="flex-1 w-full"
+                        onClick={clickThumbsUp}>
+                        {status === 'formalized' ? (
+                            <>
+                                <p className="ml-2">{upvoteCount} — VOTE</p>
+                            </>
+                        ) : (
+                            <>
+                                <ThumbsUp size={20} />{' '}
+                                <p className="ml-2">{upvoteCount}</p>
+                            </>
+                        )}
+                    </Button>
+                    <Button
+                        variant={
+                            userVote === -1 || userVote === 0
+                                ? 'default'
+                                : 'outline'
+                        }
+                        intent={'default'}
+                        className="flex-1 w-full"
+                        size={'lg'}
+                        onClick={clickThumbsDown}>
+                        <ThumbsDown size={20} />{' '}
+                        <p className="ml-2">{downvoteCount}</p>
                     </Button>
                 </div>
             </div>
-        </div>
+        </>
     );
 }

--- a/apps/jonogon-web-next/src/components/ui/alert-dialog.tsx
+++ b/apps/jonogon-web-next/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import * as React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+
+import {cn} from '@/lib/utils';
+import {buttonVariants} from '@/components/ui/button';
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Overlay
+        className={cn(
+            'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            className,
+        )}
+        {...props}
+        ref={ref}
+    />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({className, ...props}, ref) => (
+    <AlertDialogPortal>
+        <AlertDialogOverlay />
+        <AlertDialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+                className,
+            )}
+            {...props}
+        />
+    </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            'flex flex-col space-y-2 text-center sm:text-left',
+            className,
+        )}
+        {...props}
+    />
+);
+AlertDialogHeader.displayName = 'AlertDialogHeader';
+
+const AlertDialogFooter = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+            className,
+        )}
+        {...props}
+    />
+);
+AlertDialogFooter.displayName = 'AlertDialogFooter';
+
+const AlertDialogTitle = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Title
+        ref={ref}
+        className={cn('text-lg font-semibold', className)}
+        {...props}
+    />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Description
+        ref={ref}
+        className={cn('text-sm text-muted-foreground', className)}
+        {...props}
+    />
+));
+AlertDialogDescription.displayName =
+    AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Action>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Action
+        ref={ref}
+        className={cn(buttonVariants(), className)}
+        {...props}
+    />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Cancel
+        ref={ref}
+        className={cn(
+            buttonVariants({variant: 'outline'}),
+            'mt-2 sm:mt-0',
+            className,
+        )}
+        {...props}
+    />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+    AlertDialog,
+    AlertDialogPortal,
+    AlertDialogOverlay,
+    AlertDialogTrigger,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogFooter,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogAction,
+    AlertDialogCancel,
+};

--- a/misc/migrator/migrations/1724335170958_soft-deletion.ts
+++ b/misc/migrator/migrations/1724335170958_soft-deletion.ts
@@ -1,0 +1,18 @@
+import {ColumnDefinitions, MigrationBuilder} from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+    // Add the deleted_at column for soft deletion
+    pgm.addColumn('petitions', {
+        deleted_at: {
+            type: 'timestamp',
+            notNull: false, // Allow null for soft deletion
+        },
+    });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+    // Remove the deleted_at column if rolling back
+    pgm.dropColumn('petitions', 'deleted_at');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
 
   apps/jonogon-web-next:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-avatar':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -437,6 +440,8 @@ importers:
       wrangler:
         specifier: ^3.72.0
         version: 3.72.0(@cloudflare/workers-types@4.20240815.0)(bufferutil@4.0.8)
+
+  misc/firebase-emulator: {}
 
   misc/migrator:
     dependencies:
@@ -1756,6 +1761,19 @@ packages:
 
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
+
+  '@radix-ui/react-alert-dialog@1.1.1':
+    resolution: {integrity: sha512-wmCoJwj7byuVuiLKqDLlX7ClSUU0vd9sdCeM+2Ls+uf13+cpSJoMgwysHq1SGVVkJj5Xn0XWi1NoRCdkMpr6Mw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.0':
     resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
@@ -8795,6 +8813,20 @@ snapshots:
       '@babel/runtime': 7.25.0
 
   '@radix-ui/primitive@1.1.0': {}
+
+  '@radix-ui/react-alert-dialog@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## Implement Soft Deletion

### Related Issue
- **Soft Deletion of Petitions**: https://github.com/jonogon/jonogon-mono/issues/3

### Description
   - Implemented a soft delete feature that allows petitions to be marked as deleted without being permanently removed from the database. This ensures that we do not lose their petitions forever.
   - Added a confirmation dialog using `@radix-ui/react-alert-dialog` to prevent accidental deletions.
   - Updated the relevant API endpoints to handle soft deletion logic.
   
   **NOTE:** Once deleted the user won't be able to access the deleted petitions any more.

### Changes Made
  - Added soft delete functionality in the petition model.
  - Updated the UI to include a confirmation dialog for deletion.
  - Modified the API to support soft deletion.

## Screenshots
### Desktop:
![image](https://github.com/user-attachments/assets/38e27d1e-ae4f-4077-b4c4-c583161daae3)
![image](https://github.com/user-attachments/assets/73f8d094-0d05-48c1-953b-05b3d50ec14f)
![image](https://github.com/user-attachments/assets/e65b25ef-6da0-42ba-a1ef-3cebf983c6ae)

### Mobile:
![image](https://github.com/user-attachments/assets/2548f081-96da-4ddd-8215-af95da2bb64f)
