### PR TITLE
Min location string fix

### DIFF
--- a/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
@@ -208,7 +208,7 @@ export default function EditPetition() {
         .object({
             title: z.string().min(12),
             target: z.string().min(6),
-            location: z.string().min(6),
+            location: z.string().min(3),
             description: z.string().optional(),
         })
         .safeParse(petitionData).success;

--- a/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
@@ -221,11 +221,22 @@ export default function EditPetition() {
         const isAdmin = !!selfResponse?.meta.token.is_user_admin;
         const isMod = !!selfResponse?.meta.token.is_user_moderator;
 
-        if (!isPetitionLoading && petitionRemoteData && selfResponse) {
-            if (!(isOwnPetition || isAdmin || isMod)) {
-                router.push(`/petitions/${petition_id}`);
-                return null;
+        useEffect(() => {
+            if (!isAuthenticated) {
+                router.push(`/login?next=${encodeURIComponent(`/petitions/${petition_id}/edit`)}`);
+            } else if (!isPetitionLoading && petitionRemoteData && selfResponse) {
+                if (!(isOwnPetition || isAdmin || isMod)) {
+                    router.push(`/petitions/${petition_id}`);
+                    toast({
+                        title: 'You are not authorized to edit this petition',
+                        variant: 'destructive',
+                    });
+                }
             }
+        }, [isAuthenticated, isPetitionLoading, petitionRemoteData, selfResponse, isOwnPetition, isAdmin, isMod, router, petition_id]);
+
+        if (!isAuthenticated || (!isPetitionLoading && !(isOwnPetition || isAdmin || isMod))) {
+            return null;
         }
     return (
         <div className="flex flex-col gap-4 max-w-screen-sm mx-auto pt-5 pb-16 px-4">

--- a/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
@@ -6,7 +6,7 @@ import {useCallback, useEffect, useState} from 'react';
 import {useMutation} from '@tanstack/react-query';
 import {scope} from 'scope-utilities';
 import {TrashIcon} from '@radix-ui/react-icons';
-import {useTokenManager} from '@/auth/token-manager';
+import {useTokenManager, useAuthState} from '@/auth/token-manager';
 import {useParams, useRouter, useSearchParams} from 'next/navigation';
 import {trpc} from '@/trpc/client';
 import z from 'zod';
@@ -36,6 +36,11 @@ export default function EditPetition() {
 
     const {id: petition_id} = useParams<{id: string}>();
     const router = useRouter();
+
+    const isAuthenticated = useAuthState();
+    const { data: selfResponse } = trpc.users.getSelf.useQuery(undefined, {
+        enabled: !!isAuthenticated,
+    });
 
     const freshValue = params.get('fresh');
 
@@ -208,6 +213,20 @@ export default function EditPetition() {
         })
         .safeParse(petitionData).success;
 
+        const isOwnPetition =
+        petitionRemoteData &&
+        selfResponse &&
+        `${petitionRemoteData?.data.created_by}` === `${selfResponse?.data.id}`;
+
+        const isAdmin = !!selfResponse?.meta.token.is_user_admin;
+        const isMod = !!selfResponse?.meta.token.is_user_moderator;
+
+        if (!isPetitionLoading && petitionRemoteData && selfResponse) {
+            if (!(isOwnPetition || isAdmin || isMod)) {
+                router.push(`/petitions/${petition_id}`);
+                return null;
+            }
+        }
     return (
         <div className="flex flex-col gap-4 max-w-screen-sm mx-auto pt-5 pb-16 px-4">
             <div className="flex flex-col-reverse gap-6 sm:flex-row sm:gap-2 justify-between py-12 md:py-10">


### PR DESCRIPTION
Fixed #61 

The minimum string length for location names was set to 6, which is why shorter location names like 'Dhaka' and 'Feni' were not accepted.