### PR TITLE
Fix: Lowered minimum location string

### DIFF
--- a/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
@@ -203,7 +203,7 @@ export default function EditPetition() {
         .object({
             title: z.string().min(12),
             target: z.string().min(6),
-            location: z.string().min(6),
+            location: z.string().min(3),
             description: z.string().optional(),
         })
         .safeParse(petitionData).success;


### PR DESCRIPTION
Fixed #61 

The minimum string length for location names was set to 6, which is why shorter location names like 'Dhaka' and 'Feni' were not accepted.