### PR TITLE
Fix submit new dabi flow with deleted draft and broken ui for no petitions

### DIFF
--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
@@ -114,6 +114,7 @@ export const createPetition = protectedProcedure.mutation(
             .select(['petitions.id'])
             .where('created_by', '=', `${ctx.auth.user_id}`)
             .where('submitted_at', 'is', null)
+            .where('deleted_at', 'is', null)
             .executeTakeFirst();
 
         if (existingDraft) {

--- a/apps/jonogon-web-next/src/app/_components/PetitionList.tsx
+++ b/apps/jonogon-web-next/src/app/_components/PetitionList.tsx
@@ -12,6 +12,30 @@ import {usePathname, useRouter, useSearchParams} from 'next/navigation';
 import {useAutoAnimate} from '@formkit/auto-animate/react';
 import React, {Fragment, useEffect, useMemo, useState} from 'react';
 
+const PetitionCardsLoader = () =>
+    Array(4)
+        .fill(null)
+        .map((_, i) => {
+            return (
+                <div
+                    className={
+                        'w-full bg-border animate-pulse h-32'
+                    }
+                    key={i}></div>
+            );
+        })
+
+const NoPetitionsView = () => (
+    <div>
+        <div className={'text-center text-lg font-semibold p-5'}>
+            No দাবিs found
+        </div>
+        <div className={'text-center text-sm text-gray-500 pb-5'}>
+            Submit a new দাবি or পরে check করুন 
+        </div>
+    </div>
+);
+
 const PetitionList = () => {
     const [fuckUpOrder, setFuckupOrder] = useState(true);
 
@@ -51,9 +75,11 @@ const PetitionList = () => {
     }, [petitionRequestListResponse?.data]);
 
     const petitions = useMemo(() => {
-        if (petitionRequestListResponse?.data) {
-            if (fuckUpOrder) {
-                const nextData = [...petitionRequestListResponse.data];
+        const responseData = petitionRequestListResponse?.data;
+
+        if (responseData) {
+            if (fuckUpOrder && responseData.length > 1) {
+                const nextData = [...responseData];
 
                 const tmp = nextData[0];
                 nextData[0] = nextData[1];
@@ -61,7 +87,7 @@ const PetitionList = () => {
 
                 return nextData;
             } else {
-                return petitionRequestListResponse.data;
+                return responseData;
             }
         }
 
@@ -78,81 +104,71 @@ const PetitionList = () => {
         router.push(`${pathname}?${nextParams}`);
     };
 
+    const hasNoPetitions = petitions.length === 0;
+
     return (
         <div>
             <div className={'flex flex-col space-y-1'} ref={animationParent}>
-                {isLoading
-                    ? Array(4)
-                          .fill(null)
-                          .map((_, i) => {
-                              return (
-                                  <div
-                                      className={
-                                          'w-full bg-border animate-pulse h-32'
-                                      }
-                                      key={i}></div>
-                              );
-                          })
-                    : petitions.slice(0, 32).map((p, i) => {
-                          return (
-                              <Fragment key={p.data.id}>
-                                  <PetitionCard
-                                      id={p.data.id}
-                                      userVote={p.extras.user_vote}
-                                      mode={type}
-                                      status={p.data.status}
-                                      name={p.extras.user.name ?? ''}
-                                      title={
-                                          p.data.title ?? 'Untitled Petition'
-                                      }
-                                      attachment={p.data.attachment ?? ''}
-                                      date={
-                                          new Date(
-                                              p.data.submitted_at ??
-                                                  '1970-01-01',
-                                          )
-                                      }
-                                      target={p.data.target ?? 'Some Ministry'}
-                                      key={p.data.id ?? 0}
-                                      upvotes={
-                                          Number(
-                                              p.data.petition_upvote_count,
-                                          ) ?? 0
-                                      }
-                                      downvotes={
-                                          Number(
-                                              p.data.petition_downvote_count,
-                                          ) ?? 0
-                                      }
-                                  />
-                                  {type === 'request' &&
-                                  sort === 'votes' &&
-                                  page === 0 &&
-                                  i ===
-                                      (process.env.NODE_ENV === 'development'
-                                          ? 0
-                                          : 4) ? (
-                                      <div
-                                          key={'formalization-line'}
-                                          className={
-                                              'py-5 text-center text-green-700 flex flex-row items-center relative'
-                                          }>
-                                          <div
-                                              className={
-                                                  'border-t-2 border-dashed border-t-green-500 w-full absolute'
-                                              }></div>
-                                          <div
-                                              className={
-                                                  'top-0 pr-4 left-0 bg-background z-[1] font-semibold'
-                                              }>
-                                              ☝️ যেসব দাবি, Formalization-এর
-                                              জন্য review করা হবে
-                                          </div>
-                                      </div>
-                                  ) : null}
-                              </Fragment>
-                          );
-                      })}
+                {isLoading ? <PetitionCardsLoader />
+                : hasNoPetitions ? <NoPetitionsView />     
+                : petitions.slice(0, 32).map((p, i) => 
+                    <Fragment key={p.data.id}>
+                        <PetitionCard
+                            id={p.data.id}
+                            userVote={p.extras.user_vote}
+                            mode={type}
+                            status={p.data.status}
+                            name={p.extras.user.name ?? ''}
+                            title={
+                                p.data.title ?? 'Untitled Petition'
+                            }
+                            attachment={p.data.attachment ?? ''}
+                            date={
+                                new Date(
+                                    p.data.submitted_at ??
+                                        '1970-01-01',
+                                )
+                            }
+                            target={p.data.target ?? 'Some Ministry'}
+                            key={p.data.id ?? 0}
+                            upvotes={
+                                Number(
+                                    p.data.petition_upvote_count,
+                                ) ?? 0
+                            }
+                            downvotes={
+                                Number(
+                                    p.data.petition_downvote_count,
+                                ) ?? 0
+                            }
+                        />
+                        {type === 'request' &&
+                        sort === 'votes' &&
+                        page === 0 &&
+                        i ===
+                            (process.env.NODE_ENV === 'development'
+                                ? 0
+                                : 4) ? (
+                            <div
+                                key={'formalization-line'}
+                                className={
+                                    'py-5 text-center text-green-700 flex flex-row items-center relative'
+                                }>
+                                <div
+                                    className={
+                                        'border-t-2 border-dashed border-t-green-500 w-full absolute'
+                                    }></div>
+                                <div
+                                    className={
+                                        'top-0 pr-4 left-0 bg-background z-[1] font-semibold'
+                                    }>
+                                    ☝️ যেসব দাবি, Formalization-এর
+                                    জন্য review করা হবে
+                                </div>
+                            </div>
+                        ) : null}
+                    </Fragment>
+                )}
             </div>
             <div className={'py-4'}>
                 <Pagination>


### PR DESCRIPTION
### Broken UI for no petition 
In the newly introduced animation of reordering petitions, the assumption was that there would always be petitions to swap between, which resulted in null values being inserted into the petition array by default when the array was empty  or did not have enough items to swap.

**Fix:** check for array size before initiating swap

### Broken submit dabi when there is a soft deleted draft present
Submit dabi would break after soft deleting an existing draft as it would try to edit and submit that one draft on every subsequent retry when clicking submit dabi

**Fix:** when checking for existing drafts filter our soft deleted ones

### Misc
- Add ui for no petitions yet
- Reduce nesting in petition list jsx