### PR TITLE
Fix Unauthorized Redirect on New Petition Creation

### DIFF
--- a/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
@@ -263,7 +263,11 @@ export default function EditPetition() {
     }, [isAuthenticated, petitionRemoteData, isAdmin, isOwnPetition, petition_id]);
 
     if (isLoading) {
-        return <div>Loading...</div>;
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <div>Loading...</div>
+            </div>
+        );
     }
 
     return (

--- a/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/edit/page.tsx
@@ -234,6 +234,14 @@ export default function EditPetition() {
     const isAdmin = !!selfResponse?.meta.token.is_user_admin;
     const isMod = !!selfResponse?.meta.token.is_user_moderator;
 
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        if (petitionRemoteData) {
+            setIsLoading(false);
+        }
+    }, [petitionRemoteData]);
+
     useEffect(() => {
         if (isAuthenticated === false) {
             router.replace(
@@ -243,15 +251,20 @@ export default function EditPetition() {
     }, [isAuthenticated]);
 
     useEffect(() => {
-        if (isAuthenticated && !isOwnPetition && !isAdmin) {
-            router.push(`/petitions/${petition_id}`);
-
-            toast({
-                title: 'You are not authorized to edit this petition',
-                variant: 'destructive',
-            });
+        if (isAuthenticated && petitionRemoteData) {
+            if (!isOwnPetition && !isAdmin) {
+                router.push(`/petitions/${petition_id}`);
+                toast({
+                    title: 'You are not authorized to edit this petition',
+                    variant: 'destructive',
+                });
+            }
         }
-    }, [isAdmin, isOwnPetition]);
+    }, [isAuthenticated, petitionRemoteData, isAdmin, isOwnPetition, petition_id]);
+
+    if (isLoading) {
+        return <div>Loading...</div>;
+    }
 
     return (
         <div className="flex flex-col gap-4 max-w-screen-sm mx-auto pt-5 pb-16 px-4">


### PR DESCRIPTION
When creating a new petition, it shows the following toast:
![image](https://github.com/user-attachments/assets/27a5e6d9-1933-4c24-ab4c-3a98eeae015a)

The previous condition was to check if the user is the petition owner, moderator or admin, but when a new petition is created, the petition owner is not assigned and that's why it shows the warning and redirect. 