### PR TITLE
Minor bug in petition details page

### DIFF
--- a/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
@@ -373,7 +373,7 @@ export default function Petition() {
                         {petition.data.description ?? 'No description yet.'}
                     </Markdown>
                 )}
-                {petition?.data.attachments.filter(
+                {!!petition?.data.attachments.filter(
                     (attachment) => attachment.type === 'file',
                     ).length && (
                     <div>


### PR DESCRIPTION
## Bug Description

When no files are found in details page, it is showing '0'. This happened due to my last change [here](https://github.com/jonogon/jonogon-mono/pull/98/files#diff-d97dca8a5d0d066beb7f01e6fa7a715b0895d0d5e144bbe577e6ebf3f7d14342). It is showing the length `0` when file attachment array is empty.

https://jonogon.org/petitions/51

<img width="500" alt="Screenshot 2024-09-10 at 5 58 16 AM" src="https://github.com/user-attachments/assets/28f186e1-7309-4d83-a860-7aa8245faff1" target="_blank">

##
Updated the condition so that nothing renders if no file attachments are available.

