### PR TITLE
Filled voting button icons when clicked

### DIFF
--- a/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
@@ -421,7 +421,7 @@ export default function Petition() {
                             </>
                         ) : (
                             <>
-                                <ThumbsUp size={20} />{' '}
+                                <ThumbsUp size={20} fill={userVote === 1 ? '#000' : userVote === -1 ? '#fff' : '#28c45c' } />{' '}
                                 <p className="ml-2">{upvoteCount}</p>
                             </>
                         )}
@@ -436,7 +436,7 @@ export default function Petition() {
                         className="flex-1 w-full"
                         size={'lg'}
                         onClick={clickThumbsDown}>
-                        <ThumbsDown size={20} />{' '}
+                        <ThumbsDown size={20} fill={ userVote === 0 ? '#e03c3c' : '#fff' />{' '}
                         <p className="ml-2">{downvoteCount}</p>
                     </Button>
                 </div>


### PR DESCRIPTION
The voting buttons icon's was confusing when clicked for just only having outlined style.  This commit makes the icons fill when clicked for better understanding.

**Before-**
![before](https://github.com/user-attachments/assets/b4d88068-d2dc-4226-83ef-75823d3d1d7c)
**After-**
![votedUpdated](https://github.com/user-attachments/assets/b593ae16-825f-4956-a072-22051f53f3ef)
