### PR TITLE
Feature: Suggestions after vote modal

### DIFF
--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -253,7 +253,8 @@ export const listSuggestedPetitions = protectedProcedure
         const TIME_PERIOD = '30 days';
         const MAX_PETITIONS = 10;
 
-        const LOCATION_TARGET_WEIGHT = 5; // Higher weight for location/target-based petitions
+        const FORMALIZED_PETITION_WEIGHT = 20; // Higher weight for formalized petitions
+        const LOCATION_TARGET_WEIGHT = 5; // medium weight for location/target-based petitions
         const TRENDING_VOTES_WEIGHT = 1; // Lower weight for trending (vote count) petitions
 
         try {
@@ -306,13 +307,14 @@ export const listSuggestedPetitions = protectedProcedure
                     sql<number>`
                         (
                             CASE 
+                                WHEN petitions.formalized_at IS NOT NULL THEN ${FORMALIZED_PETITION_WEIGHT}
                                 WHEN petitions.location = ${input.location} AND petitions.target = ${input.target} 
                                 THEN ${LOCATION_TARGET_WEIGHT * 2}
                                 WHEN petitions.location = ${input.location} OR petitions.target = ${input.target} 
                                 THEN ${LOCATION_TARGET_WEIGHT} 
                                 ELSE 0 
                             END
-                            + ${TRENDING_VOTES_WEIGHT} * COALESCE(SUM(petition_votes.vote), 0)
+                            + ${TRENDING_VOTES_WEIGHT} * COUNT(petition_votes.id)
                         )
                     `.as('weighted_score'),
                 ])

--- a/apps/jonogon-core/src/api/trpc/routers/petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/routers/petitions.mts
@@ -14,13 +14,17 @@ import {
     updatePetition,
     softDeletePetition,
 } from '../procedures/petitions/crud.mjs';
-import {listPetitions} from '../procedures/petitions/listing/list-petitions.mjs';
+import {
+    listPetitions,
+    listSuggestedPetitions,
+} from '../procedures/petitions/listing/list-petitions.mjs';
 import {listPendingPetitionRequests} from '../procedures/petitions/listing/pending-petition-requests.mjs';
 
 export const petitionRouter = router({
     // CRUD
     list: listPetitions,
     listPendingPetitionRequests: listPendingPetitionRequests,
+    listSuggestedPetitions: listSuggestedPetitions,
 
     get: getPetition,
     create: createPetition,

--- a/apps/jonogon-web-next/src/app/petitions/[id]/_components/SuggestedPetitions.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_components/SuggestedPetitions.tsx
@@ -1,0 +1,128 @@
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+
+import {Button} from '@/components/ui/button';
+import {trpc} from '@/trpc/client';
+import {
+    HandThumbDownIcon as ThumbsDownIconOutline,
+    HandThumbUpIcon as ThumbsUpIconOutline,
+} from '@heroicons/react/24/outline';
+import React from 'react';
+import {useRouter} from 'next/navigation';
+
+interface Props {
+    location: string;
+    target: string;
+    petitionId: string;
+    isOpen: boolean;
+    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SuggestedPetitions = ({
+    location,
+    target,
+    petitionId,
+    isOpen,
+    setIsOpen,
+}: Props) => {
+    const {data: suggestedPetitions, isLoading} =
+        trpc.petitions.listSuggestedPetitions.useQuery({
+            location,
+            target,
+            petitionId,
+        });
+
+    const router = useRouter();
+
+    return (
+        <>
+            {!isLoading &&
+                suggestedPetitions &&
+                suggestedPetitions?.data?.length > 0 && (
+                    <Sheet open={isOpen} onOpenChange={setIsOpen}>
+                        <SheetContent
+                            side="bottom"
+                            className="max-w-screen-sm mx-auto !rounded-t-2xl ring-0 border-0 focus-visible:ring-offset-0 focus-visible:ring-0">
+                            <SheetHeader>
+                                <SheetTitle className="text-red-500 text-left">
+                                    Checkout other দাবি's that might interest
+                                    you
+                                </SheetTitle>
+                                <SheetDescription>
+                                    <div className="max-h-[275px] pr-4 overflow-y-auto mt-2">
+                                        {suggestedPetitions.data.map(
+                                            (petition) => (
+                                                <div
+                                                    className="[&:not(:last-child)]:border-b border-zinc-200 "
+                                                    key={petition.id}
+                                                    onClick={() =>
+                                                        router.push(
+                                                            `/petitions/${petition.id}`,
+                                                        )
+                                                    }>
+                                                    <div className="flex items-start justify-between gap-3 sm:gap-4 py-4  cursor-pointer">
+                                                        {/* For Attachments */}
+                                                        {petition.attachments && (
+                                                            <div className="size-20 min-w-20 object-cover">
+                                                                <img
+                                                                    src={`${
+                                                                        petition.attachments
+                                                                    }`.replace(
+                                                                        '$CORE_HOSTNAME',
+                                                                        window
+                                                                            .location
+                                                                            .hostname,
+                                                                    )}
+                                                                    className="w-full h-full object-cover bg-red-500"
+                                                                />
+                                                            </div>
+                                                        )}
+                                                        <div className="flex-1 h-20 flex flex-col justify-between">
+                                                            <h3 className="text-black font-medium text-lg leading-snug mb-3 line-clamp-2 text-left">
+                                                                {petition.title}
+                                                            </h3>
+                                                            <div className="flex items-center gap-6">
+                                                                <div className="flex items-center gap-2">
+                                                                    <ThumbsUpIconOutline className="size-5 text-green-500" />
+                                                                    <p className="font-semibold">
+                                                                        {
+                                                                            petition.upvotes
+                                                                        }
+                                                                    </p>
+                                                                </div>
+                                                                <div className="flex items-center gap-2">
+                                                                    <ThumbsDownIconOutline className="size-5 text-red-500" />
+                                                                    <p className="font-semibold">
+                                                                        {
+                                                                            petition.downvotes
+                                                                        }
+                                                                    </p>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <Button
+                                                            size={'sm'}
+                                                            variant={'outline'}
+                                                            className="hidden sm:flex">
+                                                            Vote
+                                                        </Button>
+                                                    </div>
+                                                </div>
+                                            ),
+                                        )}
+                                    </div>
+                                </SheetDescription>
+                            </SheetHeader>
+                        </SheetContent>
+                    </Sheet>
+                )}
+        </>
+    );
+};
+
+export default SuggestedPetitions;

--- a/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
@@ -14,12 +14,13 @@ import {useEffect, useState} from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import {useSocialShareStore} from '@/store/useSocialShareStore';
 import {PetitionShareModal} from './_components/PetitionShareModal';
 import {SocialShareSheet} from './_components/SocialShareSheet';
-import {useSocialShareStore} from '@/store/useSocialShareStore';
 
 import {ThumbsDown, ThumbsUp} from 'lucide-react';
 import CommentThread from './_components/comments/Thread';
+import SuggestedPetitions from './_components/SuggestedPetitions';
 
 export default function Petition() {
     const utils = trpc.useUtils();
@@ -48,6 +49,8 @@ export default function Petition() {
 
     const [userVote, setUserVote] = useState(0);
     const [showSuccessModal, setShowSuccessModal] = useState(false);
+    const [showSuggestedPetitionsModal, setShowSuggestedPetitionsModal] =
+        useState(false);
 
     useEffect(() => {
         if (isSubmitted) {
@@ -61,8 +64,12 @@ export default function Petition() {
         }
     }, [petition]);
 
-    const thumbsUpMutation = trpc.petitions.vote.useMutation();
-    const thumbsDownMutation = trpc.petitions.vote.useMutation();
+    const thumbsUpMutation = trpc.petitions.vote.useMutation({
+        onSuccess: () => setShowSuggestedPetitionsModal(true),
+    });
+    const thumbsDownMutation = trpc.petitions.vote.useMutation({
+        onSuccess: () => setShowSuggestedPetitionsModal(true),
+    });
     const clearVoteMutation = trpc.petitions.clearVote.useMutation();
 
     const clickThumbsUp = async () => {
@@ -353,7 +360,7 @@ export default function Petition() {
                     {petition?.data.status !== 'rejected' &&
                         petition?.data.status !== 'draft' && (
                             <div
-                                className="flex items-center gap-1.5 text-primary/80 rounded-2xl border px-4 py-2 hover:border-red-500 hover:text-red-500 transition-colors"
+                                className="flex items-center gap-1.5 text-primary/80 rounded-2xl border px-4 py-2 mt-4 hover:border-red-500 hover:text-red-500 transition-colors"
                                 role="button"
                                 onClick={() => openShareModal()}>
                                 <Share2 className="size-3" />
@@ -370,32 +377,31 @@ export default function Petition() {
                 </div>
                 <ImageCarousel />
                 {petition?.data.description && (
-                    <Markdown 
-                    remarkPlugins={[remarkGfm]} 
-                    className="prose prose-a:text-blue-600 prose-a:underline hover:prose-a:no-underline"
-                >
+                    <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        className="prose prose-a:text-blue-600 prose-a:underline hover:prose-a:no-underline">
                         {petition.data.description ?? 'No description yet.'}
                     </Markdown>
                 )}
                 {!!petition?.data.attachments.filter(
                     (attachment) => attachment.type === 'file',
-                    ).length && (
+                ).length && (
                     <div>
                         <h2 className="text-lg font-bold">Files</h2>
                         {petition.data.attachments
                             .filter((attachment) => attachment.type === 'file')
                             .map((attachment, a) => (
-                            <a
-                                className="text-sm text-blue-400 underline block"
-                                key={a}
+                                <a
+                                    className="text-sm text-blue-400 underline block"
+                                    key={a}
                                     href={attachment.attachment.replace(
                                         '$CORE_HOSTNAME',
                                         window.location.hostname,
-                                    )} target="_blank"
-                            >
-                            {attachment.filename}
-                            </a>
-                        ))}
+                                    )}
+                                    target="_blank">
+                                    {attachment.filename}
+                                </a>
+                            ))}
                     </div>
                 )}
                 <CommentThread />
@@ -445,6 +451,16 @@ export default function Petition() {
                     <PetitionShareModal
                         isOpen={showSuccessModal}
                         setIsOpen={setShowSuccessModal}
+                    />
+                )}
+
+                {showSuggestedPetitionsModal && (
+                    <SuggestedPetitions
+                        petitionId={petition?.data.id ?? ''}
+                        location={petition?.data.location ?? ''}
+                        target={petition?.data.target ?? ''}
+                        isOpen={showSuggestedPetitionsModal}
+                        setIsOpen={setShowSuggestedPetitionsModal}
                     />
                 )}
 


### PR DESCRIPTION
1. Implemented a suggestion modal that appears when users upvote or downvote a petition.
2. The suggestion feed dynamically provides petitions based on relevance, including:
     - Similar petitions by location or target.
     - Trending petitions with the highest votes within the last 30 days.
For this, implement a basic weighted mechanism to rank petitions based on these metrics (location, target, and vote count)

Ticket: https://abrarsami.notion.site/Suggestions-after-vote-modal-b5220fb64fd9494d9969a5758c69ae4f