### PR TITLE
Reset page number when changing tab to all dabi/formalized dabi.

### DIFF
--- a/apps/jonogon-web-next/src/app/page.tsx
+++ b/apps/jonogon-web-next/src/app/page.tsx
@@ -60,8 +60,11 @@ function Tab({
 
     const updateParams = () => {
         const nextSearchParams = new URLSearchParams(params);
+        const clickedSameType = nextSearchParams.get('type') === null || nextSearchParams.get('type') === type;
         nextSearchParams.set('type', type);
-
+        if (!clickedSameType) {
+            nextSearchParams.delete('page');
+        }
         router.replace('/?' + nextSearchParams.toString());
     };
 


### PR DESCRIPTION
Currently, when a user goes to the 2'nd page of **All Dabi** tab and then switch the tab to **Formalized Dabi** tab, then this tab also stores the page number thus there is no data showing on this page. The user can not go to the previous page as there is no pagination in here too.
So, when a user changes tabs, then the pagination should get reset.

https://github.com/user-attachments/assets/8b59a2e0-3241-4f04-8004-3bdfb952b705

