### PR TITLE
Improve Pagination in the Homepage

### DIFF
--- a/apps/jonogon-web-next/src/app/_components/PetitionList.tsx
+++ b/apps/jonogon-web-next/src/app/_components/PetitionList.tsx
@@ -181,29 +181,29 @@ const PetitionList = () => {
                     ))
                 )}
             </div>
-            {!isLoading && petitions.length >= 32 && (
+            {!isLoading && petitions.length > 0 && (
                 <div className={'py-4'}>
                     <Pagination>
                         <PaginationContent>
-                            {page !== 0 ? (
+                            {page > 0 && (
                                 <PaginationItem>
                                     <PaginationPrevious
                                         onClick={() => setPage(page - 1)}
                                     />
                                 </PaginationItem>
-                            ) : null}
+                            )}
 
                             <PaginationItem>
-                                <PaginationLink>Page {page + 1}</PaginationLink>
+                                <PaginationLink>{page + 1}</PaginationLink>
                             </PaginationItem>
 
-                            {petitions.length === 33 ? (
+                            {petitions.length === 33 && (
                                 <PaginationItem>
                                     <PaginationNext
                                         onClick={() => setPage(page + 1)}
                                     />
                                 </PaginationItem>
-                            ) : null}
+                            )}
                         </PaginationContent>
                     </Pagination>
                 </div>

--- a/apps/jonogon-web-next/src/components/ui/pagination.tsx
+++ b/apps/jonogon-web-next/src/components/ui/pagination.tsx
@@ -52,7 +52,8 @@ const PaginationLink = ({
                 variant: isActive ? 'outline' : 'ghost',
                 size,
             }),
-            className,
+            'cursor-pointer',
+            className
         )}
         {...props}
     />


### PR DESCRIPTION
1. If we visit the last page of the petition list, it does not show any pagination to go back or go to the previous page. 

Previously:
![image](https://github.com/user-attachments/assets/2b6ea880-d82f-4941-99d6-78510d2c3a73)

Now:
![image](https://github.com/user-attachments/assets/4e265bca-3524-416e-9f48-37388a6d4ac2)

2. The buttons of the pagination show text cursor instead of pointer. Fixed it. 

