### PR TITLE
feat: backend logic integration for flagging dabis

### DIFF
--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/crud.mts
@@ -37,6 +37,8 @@ export const getPetition = publicProcedure
                 'petitions.submitted_at',
                 'petitions.rejected_at',
                 'petitions.rejection_reason',
+                `petitions.flagged_at`,
+                `petitions.flagged_reason`,
                 'petitions.approved_at',
                 'petitions.formalized_at',
                 'petition_votes.vote as user_vote',

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -12,8 +12,10 @@ import {removeStopwords, eng, ben} from 'stopword';
 export const listPetitions = publicProcedure
     .input(
         z.object({
-            filter: z.enum(['request', 'formalized', 'own']).default('request'),
-            sort: z.enum(['time', 'votes', 'flag']).default('votes'),
+            filter: z
+                .enum(['request', 'formalized', 'own', 'flagged'])
+                .default('request'),
+            sort: z.enum(['time', 'votes']).default('votes'),
             order: z.enum(['asc', 'desc']).default('desc'),
             page: z.number().default(0),
         }),
@@ -44,67 +46,38 @@ export const listPetitions = publicProcedure
                                 ]),
                         ).let((query) => {
                             if (input.filter === 'request') {
-                                if (input.sort === 'flag') {
-                                    return query
-                                        .where(
-                                            'petitions.approved_at',
-                                            'is not',
-                                            null,
-                                        )
-                                        .where(
-                                            'petitions.formalized_at',
-                                            'is',
-                                            null,
-                                        )
-                                        .where(
-                                            'petitions.flagged_at',
-                                            'is not',
-                                            null,
-                                        );
-                                } else {
-                                    return query
-                                        .where(
-                                            'petitions.approved_at',
-                                            'is not',
-                                            null,
-                                        )
-                                        .where(
-                                            'petitions.formalized_at',
-                                            'is',
-                                            null,
-                                        )
-                                        .where(
-                                            'petitions.flagged_at',
-                                            'is',
-                                            null,
-                                        );
-                                }
+                                return query
+                                    .where(
+                                        'petitions.approved_at',
+                                        'is not',
+                                        null,
+                                    )
+                                    .where(
+                                        'petitions.formalized_at',
+                                        'is',
+                                        null,
+                                    )
+                                    .where('petitions.flagged_at', 'is', null);
                             } else if (input.filter === 'formalized') {
-                                if (input.sort === 'flag') {
-                                    return query
-                                        .where(
-                                            'petitions.formalized_at',
-                                            'is not',
-                                            null,
-                                        )
-                                        .where(
-                                            'petitions.flagged_at',
-                                            'is not',
-                                            null,
-                                        );
-                                } else {
-                                    return query
-                                        .where(
-                                            'petitions.formalized_at',
-                                            'is not',
-                                            null,
-                                        )
-                                        .where(
-                                            'petitions.flagged_at',
-                                            'is',
-                                            null,
-                                        );
-                                }
+                                return query
+                                    .where(
+                                        'petitions.formalized_at',
+                                        'is not',
+                                        null,
+                                    )
+                                    .where('petitions.flagged_at', 'is', null);
+                            } else if (input.filter == 'flagged') {
+                                return query
+                                    .where(
+                                        'petitions.approved_at',
+                                        'is not',
+                                        null,
+                                    )
+                                    .where(
+                                        'petitions.flagged_at',
+                                        'is not',
+                                        null,
+                                    );
                             } else {
                                 return query;
                             }

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -45,11 +45,22 @@ export const listPetitions = publicProcedure
                         ).let((query) => {
                             if (input.filter === 'request') {
                                 if (input.sort === 'flag') {
-                                    return query.where(
-                                        'petitions.formalized_at',
-                                        'is not',
-                                        null,
-                                    );
+                                    return query
+                                        .where(
+                                            'petitions.approved_at',
+                                            'is not',
+                                            null,
+                                        )
+                                        .where(
+                                            'petitions.formalized_at',
+                                            'is',
+                                            null,
+                                        )
+                                        .where(
+                                            'petitions.flagged_at',
+                                            'is not',
+                                            null,
+                                        );
                                 } else {
                                     return query
                                         .where(
@@ -69,11 +80,31 @@ export const listPetitions = publicProcedure
                                         );
                                 }
                             } else if (input.filter === 'formalized') {
-                                return query.where(
-                                    'petitions.formalized_at',
-                                    'is not',
-                                    null,
-                                );
+                                if (input.sort === 'flag') {
+                                    return query
+                                        .where(
+                                            'petitions.formalized_at',
+                                            'is not',
+                                            null,
+                                        )
+                                        .where(
+                                            'petitions.flagged_at',
+                                            'is not',
+                                            null,
+                                        );
+                                } else {
+                                    return query
+                                        .where(
+                                            'petitions.formalized_at',
+                                            'is not',
+                                            null,
+                                        )
+                                        .where(
+                                            'petitions.flagged_at',
+                                            'is',
+                                            null,
+                                        );
+                                }
                             } else {
                                 return query;
                             }

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/listing/list-petitions.mts
@@ -260,7 +260,8 @@ export const listPetitions = publicProcedure
                 )
                 .where('petitions.formalized_at', 'is not', null)
                 .where('petitions.deleted_at', 'is', null)
-                .where('petition_votes.vote', 'is', null)
+                .where('petitions.flagged_at', 'is', null) // Ensure the petition is not flagged
+                .where('petition_votes.vote', 'is', null) // Ensure the user has not voted
                 .select(({fn}) => fn.count('petitions.id').as('count'))
                 .execute();
 

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
@@ -96,7 +96,6 @@ export const flag = protectedProcedure
         const result = await ctx.services.postgresQueryBuilder
             .updateTable('petitions')
             .set({
-                approved_at: null, // Reset the approved_at timestamp
                 rejected_at: null, // Reset the rejected_at timestamp
                 rejection_reason: null, // Reset the rejection_reason
                 formalized_at: null, // Reset the formalized_at timestamp

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
@@ -98,7 +98,6 @@ export const flag = protectedProcedure
             .set({
                 rejected_at: null, // Reset the rejected_at timestamp
                 rejection_reason: null, // Reset the rejection_reason
-                formalized_at: null, // Reset the formalized_at timestamp
 
                 flagged_at: new Date(), // Set the current timestamp
                 flagged_reason: input.reason, // Set the reason for flagging
@@ -143,6 +142,8 @@ export const formalize = protectedProcedure
 
                 rejected_at: null,
                 rejection_reason: null,
+                flagged_at: null,
+                flagged_reason: null,
 
                 upvote_target: input.upvote_target,
             })

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
@@ -13,6 +13,8 @@ export const approve = protectedProcedure
             .set({
                 rejected_at: null,
                 rejection_reason: null,
+                flagged_at: null,
+                flagged_reason: null,
                 formalized_at: null,
 
                 approved_at: new Date(),
@@ -52,6 +54,8 @@ export const reject = protectedProcedure
             .updateTable('petitions')
             .set({
                 approved_at: null,
+                flagged_at: null,
+                flagged_reason: null,
                 formalized_at: null,
 
                 rejected_at: new Date(),
@@ -77,6 +81,50 @@ export const reject = protectedProcedure
         return {
             input,
             message: 'rejected',
+        };
+    });
+
+export const flag = protectedProcedure
+    .input(
+        z.object({
+            petition_id: z.number(),
+            reason: z.string(),
+        }),
+    )
+    .mutation(async ({input, ctx}) => {
+        // Update the petition to set flagged_at and flagged_reason
+        const result = await ctx.services.postgresQueryBuilder
+            .updateTable('petitions')
+            .set({
+                approved_at: null, // Reset the approved_at timestamp
+                rejected_at: null, // Reset the rejected_at timestamp
+                rejection_reason: null, // Reset the rejection_reason
+                formalized_at: null, // Reset the formalized_at timestamp
+
+                flagged_at: new Date(), // Set the current timestamp
+                flagged_reason: input.reason, // Set the reason for flagging
+                moderated_by: ctx.auth.user_id, // Set the user who flagged
+            })
+            .where('id', '=', `${input.petition_id}`)
+            .returning(['id', 'created_by'])
+            .executeTakeFirst();
+
+        // If the petition was successfully updated, create a notification
+        if (result) {
+            await ctx.services.postgresQueryBuilder
+                .insertInto('notifications')
+                .values({
+                    user_id: result.created_by, // Notify the creator of the petition
+                    type: 'petition_flagged', // Type of notification
+                    actor_user_id: ctx.auth.user_id, // The user who flagged the petition
+                    petition_id: input.petition_id,
+                })
+                .executeTakeFirst();
+        }
+
+        return {
+            input,
+            message: 'flagged',
         };
     });
 
@@ -118,44 +166,5 @@ export const formalize = protectedProcedure
         return {
             input,
             message: 'formalized',
-        };
-    });
-
-export const flag = protectedProcedure
-    .input(
-        z.object({
-            petition_id: z.number(),
-            reason: z.string(),
-        }),
-    )
-    .mutation(async ({input, ctx}) => {
-        // Update the petition to set flagged_at and flagged_reason
-        const result = await ctx.services.postgresQueryBuilder
-            .updateTable('petitions')
-            .set({
-                flagged_at: new Date(), // Set the current timestamp
-                flagged_reason: input.reason, // Set the reason for flagging
-                moderated_by: ctx.auth.user_id, // Set the user who flagged
-            })
-            .where('id', '=', `${input.petition_id}`)
-            .returning(['id', 'created_by'])
-            .executeTakeFirst();
-
-        // If the petition was successfully updated, create a notification
-        if (result) {
-            await ctx.services.postgresQueryBuilder
-                .insertInto('notifications')
-                .values({
-                    user_id: result.created_by, // Notify the creator of the petition
-                    type: 'petition_flagged', // Type of notification
-                    actor_user_id: ctx.auth.user_id, // The user who flagged the petition
-                    petition_id: input.petition_id,
-                })
-                .executeTakeFirst();
-        }
-
-        return {
-            input,
-            message: 'flagged',
         };
     });

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/moderation.mts
@@ -98,6 +98,7 @@ export const flag = protectedProcedure
             .set({
                 rejected_at: null, // Reset the rejected_at timestamp
                 rejection_reason: null, // Reset the rejection_reason
+                formalized_at: null, // Reset the formalized_at timestamp
 
                 flagged_at: new Date(), // Set the current timestamp
                 flagged_reason: input.reason, // Set the reason for flagging

--- a/apps/jonogon-core/src/api/trpc/procedures/petitions/voting.mts
+++ b/apps/jonogon-core/src/api/trpc/procedures/petitions/voting.mts
@@ -1,4 +1,5 @@
 import {protectedProcedure} from '../../middleware/protected.mjs';
+import {TRPCError} from '@trpc/server';
 import {z} from 'zod';
 
 export const vote = protectedProcedure
@@ -9,6 +10,28 @@ export const vote = protectedProcedure
         }),
     )
     .mutation(async ({input, ctx}) => {
+        // Check if the petition is flagged
+        const petition = await ctx.services.postgresQueryBuilder
+            .selectFrom('petitions')
+            .where('id', '=', input.petition_id)
+            .select(['flagged_at', 'created_by']) // Select flagged_at to check if the petition is flagged
+            .executeTakeFirst();
+
+        if (!petition) {
+            throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: 'petition-not-found',
+            });
+        }
+
+        // If the petition is flagged, prevent voting
+        if (petition.flagged_at) {
+            throw new TRPCError({
+                code: 'FORBIDDEN',
+                message: 'voting is not allowed on flagged petitions',
+            });
+        }
+
         const result = await ctx.services.postgresQueryBuilder
             .insertInto('petition_votes')
             .values({

--- a/apps/jonogon-core/src/api/trpc/routers/petitions.mts
+++ b/apps/jonogon-core/src/api/trpc/routers/petitions.mts
@@ -1,6 +1,7 @@
 import {router} from '../index.mjs';
 import {
     approve,
+    flag,
     formalize,
     reject,
 } from '../procedures/petitions/moderation.mjs';
@@ -48,4 +49,5 @@ export const petitionRouter = router({
     approve: approve,
     reject: reject,
     formalize: formalize,
+    flag: flag,
 });

--- a/apps/jonogon-core/src/db/model-utils/petition.mts
+++ b/apps/jonogon-core/src/db/model-utils/petition.mts
@@ -5,6 +5,7 @@ export function deriveStatus(petition: {
     approved_at: SelectType<Petitions['approved_at']>;
     formalized_at: SelectType<Petitions['formalized_at']>;
     rejected_at: SelectType<Petitions['rejected_at']>;
+    flagged_at: SelectType<Petitions['flagged_at']>;
     submitted_at: SelectType<Petitions['submitted_at']>;
 }) {
     if (petition.formalized_at) {
@@ -17,6 +18,10 @@ export function deriveStatus(petition: {
 
     if (petition.rejected_at) {
         return 'rejected' as const;
+    }
+
+    if (petition.flagged_at) {
+        return 'flagged' as const;
     }
 
     if (petition.submitted_at) {

--- a/apps/jonogon-core/src/db/model-utils/petition.mts
+++ b/apps/jonogon-core/src/db/model-utils/petition.mts
@@ -8,12 +8,12 @@ export function deriveStatus(petition: {
     flagged_at: SelectType<Petitions['flagged_at']>;
     submitted_at: SelectType<Petitions['submitted_at']>;
 }) {
-    if (petition.formalized_at) {
-        return 'formalized' as const;
-    }
-
     if (petition.flagged_at) {
         return 'flagged' as const;
+    }
+
+    if (petition.formalized_at) {
+        return 'formalized' as const;
     }
 
     if (petition.approved_at) {

--- a/apps/jonogon-core/src/db/model-utils/petition.mts
+++ b/apps/jonogon-core/src/db/model-utils/petition.mts
@@ -12,16 +12,16 @@ export function deriveStatus(petition: {
         return 'formalized' as const;
     }
 
+    if (petition.flagged_at) {
+        return 'flagged' as const;
+    }
+
     if (petition.approved_at) {
         return 'approved' as const;
     }
 
     if (petition.rejected_at) {
         return 'rejected' as const;
-    }
-
-    if (petition.flagged_at) {
-        return 'flagged' as const;
     }
 
     if (petition.submitted_at) {

--- a/apps/jonogon-core/src/db/postgres/types.mts
+++ b/apps/jonogon-core/src/db/postgres/types.mts
@@ -84,6 +84,8 @@ export interface Petitions {
   moderated_by: Int8 | null;
   rejected_at: Timestamp | null;
   rejection_reason: string | null;
+  flagged_at: Timestamp | null;
+  flagged_reason: string | null;
   submitted_at: Timestamp | null;
   target: string | null;
   title: string | null;

--- a/apps/jonogon-core/src/services/queues/smsNotificationDispatchQueue.mts
+++ b/apps/jonogon-core/src/services/queues/smsNotificationDispatchQueue.mts
@@ -100,7 +100,11 @@ export function processSmsNotificationDispatchQueue(services: TServices) {
 
         // PETITION MODERATION
         const petitionStatus: {
-            [petition_id: string]: 'approved' | 'rejected' | 'formalized';
+            [petition_id: string]:
+                | 'approved'
+                | 'rejected'
+                | 'flagged'
+                | 'formalized';
         } = {};
 
         for (const notification of grouped.petition_approved ?? []) {
@@ -112,6 +116,12 @@ export function processSmsNotificationDispatchQueue(services: TServices) {
         for (const notification of grouped.petition_rejected ?? []) {
             if (notification.petition_id) {
                 petitionStatus[notification.petition_id] = 'rejected';
+            }
+        }
+
+        for (const notification of grouped.petition_flagged ?? []) {
+            if (notification.petition_id) {
+                petitionStatus[notification.petition_id] = 'flagged';
             }
         }
 
@@ -128,6 +138,7 @@ export function processSmsNotificationDispatchQueue(services: TServices) {
 
         const approvedPetitionCount = petitionStatusCounts.approved ?? 0;
         const rejectedPetitionCount = petitionStatusCounts.rejected ?? 0;
+        const flaggedPetitionCount = petitionStatusCounts.flagged ?? 0;
         const formalizedPetitionCount = petitionStatusCounts.formalized ?? 0;
 
         // PETITION MILESTONES
@@ -211,6 +222,16 @@ export function processSmsNotificationDispatchQueue(services: TServices) {
             } else {
                 messageParts.push(
                     `- ${rejectedPetitionCount} petitions were rejected\n`,
+                );
+            }
+        }
+
+        if (flaggedPetitionCount > 0) {
+            if (flaggedPetitionCount === 1) {
+                messageParts.push('- 1 petition was flagged\n');
+            } else {
+                messageParts.push(
+                    `- ${flaggedPetitionCount} petitions were flagged\n`,
                 );
             }
         }

--- a/apps/jonogon-web-next/src/app/_components/petitionSortUtils.ts
+++ b/apps/jonogon-web-next/src/app/_components/petitionSortUtils.ts
@@ -1,7 +1,6 @@
 export function getSortType(sortStr: string | null) {
     switch (sortStr) {
         case 'time':
-        case 'flag':
         case 'votes':
             return sortStr;
         default:
@@ -28,7 +27,6 @@ export function getDefaultSortForDabiType(
     if (type === 'own') {
         switch (sort) {
             case 'votes':
-            case 'flag':
             case 'time':
                 return sort;
             default:
@@ -38,7 +36,6 @@ export function getDefaultSortForDabiType(
 
     switch (sort) {
         case 'votes':
-        case 'flag':
         case 'time':
             return sort;
         default:
@@ -54,8 +51,6 @@ export function getDefaultSortLabelForDabiType(
         switch (sort) {
             case 'votes':
                 return 'বেশি Votes';
-            case 'flag':
-                return 'Flagged দাবিs';
             case 'time':
             default:
                 return 'Latest';
@@ -65,8 +60,6 @@ export function getDefaultSortLabelForDabiType(
     switch (sort) {
         case 'time':
             return 'Latest';
-        case 'flag':
-            return 'Flagged দাবিs';
         case 'votes':
         default:
             return 'বেশি Votes';

--- a/apps/jonogon-web-next/src/app/_components/petitionSortUtils.ts
+++ b/apps/jonogon-web-next/src/app/_components/petitionSortUtils.ts
@@ -1,6 +1,7 @@
 export function getSortType(sortStr: string | null) {
     switch (sortStr) {
         case 'time':
+        case 'flag':
         case 'votes':
             return sortStr;
         default:
@@ -22,11 +23,12 @@ export function getDabiType(typeStr: string | null) {
 // maybe move somewhere else and rename??
 export function getDefaultSortForDabiType(
     sort: ReturnType<typeof getSortType>,
-    type: ReturnType<typeof getDabiType>
+    type: ReturnType<typeof getDabiType>,
 ) {
     if (type === 'own') {
         switch (sort) {
             case 'votes':
+            case 'flag':
             case 'time':
                 return sort;
             default:
@@ -36,6 +38,7 @@ export function getDefaultSortForDabiType(
 
     switch (sort) {
         case 'votes':
+        case 'flag':
         case 'time':
             return sort;
         default:
@@ -45,12 +48,14 @@ export function getDefaultSortForDabiType(
 
 export function getDefaultSortLabelForDabiType(
     sort: ReturnType<typeof getSortType>,
-    type: ReturnType<typeof getDabiType>
+    type: ReturnType<typeof getDabiType>,
 ) {
     if (type === 'own') {
         switch (sort) {
             case 'votes':
                 return 'বেশি Votes';
+            case 'flag':
+                return 'Flagged দাবিs';
             case 'time':
             default:
                 return 'Latest';
@@ -60,6 +65,8 @@ export function getDefaultSortLabelForDabiType(
     switch (sort) {
         case 'time':
             return 'Latest';
+        case 'flag':
+            return 'Flagged দাবিs';
         case 'votes':
         default:
             return 'বেশি Votes';

--- a/apps/jonogon-web-next/src/app/page.tsx
+++ b/apps/jonogon-web-next/src/app/page.tsx
@@ -25,7 +25,7 @@ import {trpc} from '@/trpc/client';
 function SortOption({
     sort,
     children,
-}: PropsWithChildren<{sort: 'time' | 'votes'}>) {
+}: PropsWithChildren<{sort: 'time' | 'votes' | 'flag'}>) {
     const router = useRouter();
     const params = useSearchParams();
 
@@ -60,7 +60,9 @@ function Tab({
 
     const updateParams = () => {
         const nextSearchParams = new URLSearchParams(params);
-        const clickedSameType = nextSearchParams.get('type') === null || nextSearchParams.get('type') === type;
+        const clickedSameType =
+            nextSearchParams.get('type') === null ||
+            nextSearchParams.get('type') === type;
         nextSearchParams.set('type', type);
         if (!clickedSameType) {
             nextSearchParams.delete('page');
@@ -115,10 +117,10 @@ export default function Home() {
     const typeSeq =
         userCount > 0
             ? [
-                ...defaultTypeSeq,
-                `${userCount + DISCORD_COMMUNITY_SIZE} নাগরিক এর সাথে\nগড়ে তুলুন নতুন দেশ`,
-                2000,
-            ]
+                  ...defaultTypeSeq,
+                  `${userCount + DISCORD_COMMUNITY_SIZE} নাগরিক এর সাথে\nগড়ে তুলুন নতুন দেশ`,
+                  2000,
+              ]
             : defaultTypeSeq;
 
     return (
@@ -158,6 +160,7 @@ export default function Home() {
                         <DropdownMenuContent align="end">
                             <SortOption sort={'votes'}>বেশি Votes</SortOption>
                             <SortOption sort={'time'}>Latest</SortOption>
+                            <SortOption sort={'flag'}>Flagged</SortOption>
                         </DropdownMenuContent>
                     </DropdownMenu>
                 </div>

--- a/apps/jonogon-web-next/src/app/page.tsx
+++ b/apps/jonogon-web-next/src/app/page.tsx
@@ -25,7 +25,7 @@ import {trpc} from '@/trpc/client';
 function SortOption({
     sort,
     children,
-}: PropsWithChildren<{sort: 'time' | 'votes' | 'flag'}>) {
+}: PropsWithChildren<{sort: 'time' | 'votes'}>) {
     const router = useRouter();
     const params = useSearchParams();
 
@@ -160,7 +160,6 @@ export default function Home() {
                         <DropdownMenuContent align="end">
                             <SortOption sort={'votes'}>বেশি Votes</SortOption>
                             <SortOption sort={'time'}>Latest</SortOption>
-                            <SortOption sort={'flag'}>Flagged</SortOption>
                         </DropdownMenuContent>
                     </DropdownMenu>
                 </div>

--- a/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
@@ -44,7 +44,6 @@ export default function Petition() {
     } = trpc.petitions.get.useQuery({
         id: petition_id!!,
     });
-    const isFlagged = petition?.data.flagged_at !== null;
 
     const {openShareModal} = useSocialShareStore();
 
@@ -161,12 +160,6 @@ export default function Petition() {
         },
     });
 
-    const {mutate: flag} = trpc.petitions.flag.useMutation({
-        onSuccess: async () => {
-            await utils.petitions.get.invalidate({id: petition_id});
-        },
-    });
-
     const {mutate: formalize} = trpc.petitions.formalize.useMutation({
         onSuccess: async () => {
             await utils.petitions.get.invalidate({id: petition_id});
@@ -194,17 +187,6 @@ export default function Petition() {
                                 <div>
                                     {petition?.data.rejection_reason ?? ''}
                                 </div>
-                            </div>
-                        ) : null}
-                        {status === 'flagged' ? (
-                            <div className={'flex-1'}>
-                                <div
-                                    className={
-                                        'font-bold text-red-500 text-sm'
-                                    }>
-                                    Your petition was flagged.
-                                </div>
-                                <div>{petition?.data.flagged_reason ?? ''}</div>
                             </div>
                         ) : null}
                         {isMod || isAdmin ? (
@@ -260,8 +242,7 @@ export default function Petition() {
                                     </Button>
                                 ) : null}
                                 {status === 'submitted' ||
-                                status === 'rejected' ||
-                                status === 'flagged' ? (
+                                status === 'rejected' ? (
                                     <Button
                                         size={'sm'}
                                         intent={'success'}
@@ -295,28 +276,6 @@ export default function Petition() {
                                                 });
                                         }}>
                                         Reject
-                                    </Button>
-                                ) : null}
-                                {status !== 'rejected' &&
-                                status !== 'draft' &&
-                                status != 'flagged' ? (
-                                    <Button
-                                        size={'sm'}
-                                        intent={'default'}
-                                        onClick={() => {
-                                            const flaggedResponse =
-                                                window.prompt(
-                                                    'Why are you flagging? (leave empty to cancel)',
-                                                );
-
-                                            flaggedResponse &&
-                                                flag({
-                                                    petition_id:
-                                                        Number(petition_id),
-                                                    reason: flaggedResponse,
-                                                });
-                                        }}>
-                                        Flag
                                     </Button>
                                 ) : null}
                             </div>
@@ -473,7 +432,6 @@ export default function Petition() {
                         intent={'success'}
                         size={'lg'}
                         className="flex-1 w-full"
-                        disabled={isFlagged} // Disable if flagged
                         onClick={clickThumbsUp}>
                         {status === 'formalized' ? (
                             <>
@@ -504,7 +462,6 @@ export default function Petition() {
                         intent={'default'}
                         className="flex-1 w-full"
                         size={'lg'}
-                        disabled={isFlagged} // Disable if flagged
                         onClick={clickThumbsDown}>
                         <ThumbsDown
                             size={20}

--- a/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
@@ -195,6 +195,17 @@ export default function Petition() {
                                 </div>
                             </div>
                         ) : null}
+                        {status === 'flagged' ? (
+                            <div className={'flex-1'}>
+                                <div
+                                    className={
+                                        'font-bold text-red-500 text-sm'
+                                    }>
+                                    Your petition was flagged.
+                                </div>
+                                <div>{petition?.data.flagged_reason ?? ''}</div>
+                            </div>
+                        ) : null}
                         {isMod || isAdmin ? (
                             <div className={'flex flex-row gap-2 items-center'}>
                                 {status === 'submitted' ? (
@@ -248,7 +259,8 @@ export default function Petition() {
                                     </Button>
                                 ) : null}
                                 {status === 'submitted' ||
-                                status === 'rejected' ? (
+                                status === 'rejected' ||
+                                status === 'flagged' ? (
                                     <Button
                                         size={'sm'}
                                         intent={'success'}
@@ -284,7 +296,9 @@ export default function Petition() {
                                         Reject
                                     </Button>
                                 ) : null}
-                                {status !== 'rejected' && status !== 'draft' ? (
+                                {status !== 'rejected' &&
+                                status !== 'draft' &&
+                                status != 'flagged' ? (
                                     <Button
                                         size={'sm'}
                                         intent={'default'}

--- a/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
@@ -160,6 +160,12 @@ export default function Petition() {
         },
     });
 
+    const {mutate: flag} = trpc.petitions.flag.useMutation({
+        onSuccess: async () => {
+            await utils.petitions.get.invalidate({id: petition_id});
+        },
+    });
+
     const {mutate: formalize} = trpc.petitions.formalize.useMutation({
         onSuccess: async () => {
             await utils.petitions.get.invalidate({id: petition_id});
@@ -276,6 +282,26 @@ export default function Petition() {
                                                 });
                                         }}>
                                         Reject
+                                    </Button>
+                                ) : null}
+                                {status !== 'rejected' && status !== 'draft' ? (
+                                    <Button
+                                        size={'sm'}
+                                        intent={'default'}
+                                        onClick={() => {
+                                            const flaggedResponse =
+                                                window.prompt(
+                                                    'Why are you flagging? (leave empty to cancel)',
+                                                );
+
+                                            flaggedResponse &&
+                                                flag({
+                                                    petition_id:
+                                                        Number(petition_id),
+                                                    reason: flaggedResponse,
+                                                });
+                                        }}>
+                                        Flag
                                     </Button>
                                 ) : null}
                             </div>
@@ -439,7 +465,16 @@ export default function Petition() {
                             </>
                         ) : (
                             <>
-                                <ThumbsUp size={20} fill={userVote === 1 ? '#000' : userVote === 0 ? '#fff' : '#28c45c' } />{' '}
+                                <ThumbsUp
+                                    size={20}
+                                    fill={
+                                        userVote === 1
+                                            ? '#000'
+                                            : userVote === 0
+                                              ? '#fff'
+                                              : '#28c45c'
+                                    }
+                                />{' '}
                                 <p className="ml-2">{upvoteCount}</p>
                             </>
                         )}
@@ -454,7 +489,16 @@ export default function Petition() {
                         className="flex-1 w-full"
                         size={'lg'}
                         onClick={clickThumbsDown}>
-                            <ThumbsDown size={20} fill={userVote === -1 ? '#000' : userVote === 0 ? '#e03c3c' : '#fff'} />                            {' '}
+                        <ThumbsDown
+                            size={20}
+                            fill={
+                                userVote === -1
+                                    ? '#000'
+                                    : userVote === 0
+                                      ? '#e03c3c'
+                                      : '#fff'
+                            }
+                        />{' '}
                         <p className="ml-2">{downvoteCount}</p>
                     </Button>
                 </div>

--- a/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
+++ b/apps/jonogon-web-next/src/app/petitions/[id]/_page.tsx
@@ -44,6 +44,7 @@ export default function Petition() {
     } = trpc.petitions.get.useQuery({
         id: petition_id!!,
     });
+    const isFlagged = petition?.data.flagged_at !== null;
 
     const {openShareModal} = useSocialShareStore();
 
@@ -472,6 +473,7 @@ export default function Petition() {
                         intent={'success'}
                         size={'lg'}
                         className="flex-1 w-full"
+                        disabled={isFlagged} // Disable if flagged
                         onClick={clickThumbsUp}>
                         {status === 'formalized' ? (
                             <>
@@ -502,6 +504,7 @@ export default function Petition() {
                         intent={'default'}
                         className="flex-1 w-full"
                         size={'lg'}
+                        disabled={isFlagged} // Disable if flagged
                         onClick={clickThumbsDown}>
                         <ThumbsDown
                             size={20}

--- a/misc/migrator/migrations/1730128919409_flag-dabi.ts
+++ b/misc/migrator/migrations/1730128919409_flag-dabi.ts
@@ -1,0 +1,20 @@
+import {ColumnDefinitions, MigrationBuilder} from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+    pgm.addColumns('petitions', {
+        flagged_at: {
+            type: 'timestamp',
+            notNull: false, // Allow null for this column
+        },
+        flagged_reason: {
+            type: 'text',
+            notNull: false, // Allow null for this column
+        },
+    });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+    pgm.dropColumns('petitions', ['flagged_at', 'flagged_reason']);
+}


### PR DESCRIPTION
### The Problem:
There are instances where a moderator mistakenly approves a দাবি that DOESN’T follow the community guidelines. During those cases - these দাবিs might pick up traction and we need to “elegantly” flag these dabis so that they don’t show on the feed. 

### The Solution:
The ability to flag a দাবি by moderators - from the দাবি details page. 

Once a  দাবি is flagged the following will happen : 

- [x] It gets removed from the main feeds.
- [x] It gets stored in another filter in the dropdown as “Flagged”
- [x] These দাবিs cannot be voted on anymore BUT they can be commented on
- [x] Moderators must also have the option to “Unflag” a দাবি